### PR TITLE
Add Search Console verification and sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   package metadata.
 
 ### Added
+- Added persistent Search Console HTML verification, generated sitemap support,
+  and a crawler-visible `robots.txt` declaration for the canonical Pages site.
 - `tests/test_docs_foundation.py` guards the canonical documentation URL,
   required navigation, docs dependency extra, ignored build output, and Pages
   workflow contract.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ except PackageNotFoundError:
     release = "development"
 version = release
 
-extensions = ["myst_parser"]
+extensions = ["myst_parser", "sphinx_sitemap"]
 source_suffix = {".md": "markdown"}
 root_doc = "index"
 language = "en"
@@ -24,6 +24,7 @@ html_theme = "alabaster"
 html_title = "trendfollowing documentation"
 html_short_title = "trendfollowing"
 html_baseurl = "https://artursepp.github.io/TrendFollowingSystems/"
+html_extra_path = ["robots.txt"]
 html_theme_options = {
     "description": "Closed-form trend-following analytics and reproducible futures evidence",
     "github_button": True,
@@ -43,7 +44,11 @@ myst_html_meta = {
     "keywords": (
         "trend-following, time-series momentum, managed futures, quantitative finance, Python"
     ),
+    "google-site-verification": "WJen7v3RzYStpnJNMjZL5X35cuWl__U-MBvZtgN65-g",
 }
+
+sitemap_url_scheme = "{link}"
+sitemap_indent = 2
 
 linkcheck_retries = 2
 linkcheck_timeout = 30

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://artursepp.github.io/TrendFollowingSystems/sitemap.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
 docs = [
     "sphinx>=7.2",
     "myst-parser>=2.0",
+    "sphinx-sitemap>=2.9",
 ]
 
 [project.urls]

--- a/tests/test_docs_foundation.py
+++ b/tests/test_docs_foundation.py
@@ -14,8 +14,11 @@ def test_sphinx_configuration_uses_canonical_url_and_myst() -> None:
 
     assert config["root_doc"] == "index"
     assert config["source_suffix"] == {".md": "markdown"}
-    assert config["extensions"] == ["myst_parser"]
+    assert config["extensions"] == ["myst_parser", "sphinx_sitemap"]
     assert config["html_baseurl"] == CANONICAL_DOCS_URL
+    assert config["html_extra_path"] == ["robots.txt"]
+    assert config["sitemap_url_scheme"] == "{link}"
+    assert config["myst_html_meta"]["google-site-verification"]
 
 
 def test_landing_page_routes_every_required_destination() -> None:
@@ -44,7 +47,16 @@ def test_docs_extra_and_ignored_build_output_are_declared() -> None:
     assert "docs = [" in pyproject
     assert '"sphinx>=7.2"' in pyproject
     assert '"myst-parser>=2.0"' in pyproject
+    assert '"sphinx-sitemap>=2.9"' in pyproject
     assert "docs/_build/" in gitignore
+
+
+def test_robots_file_allows_crawling_and_names_the_canonical_sitemap() -> None:
+    robots = (DOCS_ROOT / "robots.txt").read_text(encoding="utf-8")
+
+    assert "User-agent: *" in robots
+    assert "Allow: /" in robots
+    assert f"Sitemap: {CANONICAL_DOCS_URL}sitemap.xml" in robots
 
 
 def test_pages_workflow_builds_checks_and_deploys_documentation() -> None:


### PR DESCRIPTION
Completes the deployed-host portion of Maintainer Gate A.

- adds the persistent Search Console HTML verification tag
- generates sitemap.xml with canonical Pages URLs using sphinx-sitemap 2.9
- publishes robots.txt with the canonical sitemap location
- extends the documentation foundation guard

Failure-first evidence: deployed sitemap.xml and robots.txt both returned 404 before this change. Local HTML, XML validation, linkcheck, tests, and lint pass.