### PR TITLE
Record Maintainer Gate A completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Changed
+- Pointed package metadata and the README documentation badge to the deployed
+  canonical GitHub Pages site after Maintainer Gate A passed.
 - Established the minimal Sphinx/MyST documentation site and a warning-as-error
   GitHub Pages workflow. The server-rendered landing page routes readers to the
   quickstart, example workflows, API map, paper replication, project history,

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ engine; portfolio analytics and reporting are delegated to `qis`.
 [![Python](https://img.shields.io/pypi/pyversions/trendfollowing?style=flat-square)](https://pypi.org/project/trendfollowing/)
 [![License](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
 [![CI](https://github.com/ArturSepp/TrendFollowingSystems/actions/workflows/ci.yml/badge.svg)](https://github.com/ArturSepp/TrendFollowingSystems/actions/workflows/ci.yml)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://artursepp.github.io/TrendFollowingSystems/)
 [![Downloads](https://static.pepy.tech/badge/trendfollowing)](https://pepy.tech/project/trendfollowing)
 [![Monthly](https://static.pepy.tech/badge/trendfollowing/month)](https://pepy.tech/project/trendfollowing)
 

--- a/ROADMAP_DISCOVERABILITY_AND_ADOPTION.md
+++ b/ROADMAP_DISCOVERABILITY_AND_ADOPTION.md
@@ -6,8 +6,8 @@ Source: adapted from
 `C:\Users\artur\OneDrive\analytics\my_github\.agents\ROADMAP_OSS_DISCOVERABILITY_AND_ADOPTION.md`.
 
 Status: execution in progress. U0 and the public-data portion of U1 were recorded on 2026-08-16;
-M1, M2, U2, and U3a passed on 2026-08-16. The next step is Maintainer Gate A; no credentialed
-external action has been taken.
+M1, M2, U2, U3a, and Maintainer Gate A passed on 2026-08-16. The next implementation stage is
+U3b.
 
 ## Outcome
 
@@ -543,6 +543,8 @@ release.
 
 ## Maintainer Gate A — External identity, hosting, and indexing
 
+**Execution status (2026-08-16): PASS.** See `agents/DISCOVERABILITY_AUDIT.md`.
+
 These actions require repository and Search Console authority:
 
 1. Enable GitHub Pages for the approved workflow/environment.
@@ -960,6 +962,7 @@ Use `PASS-LOCAL` only temporarily before required deployed checks, then replace 
 2026-08-16 · M2 · main@working-tree · PASS · bundled futures resources, override contract, and artifact checks passed
 2026-08-16 · U2 · main@working-tree · PASS · canonical identity, runtime metadata, and built-artifact checks passed
 2026-08-16 · U3a · main@working-tree · PASS · warning-free HTML/linkcheck, static navigation, and Pages workflow passed
+2026-08-16 · Gate A · main@2e30bb5 · PASS · Pages, canonical GitHub identity, Search Console ownership, and sitemap submission completed
 ```
 
 ## Definition of complete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/ArturSepp/TrendFollowingSystems"
-Documentation = "https://github.com/ArturSepp/TrendFollowingSystems#readme"
+Documentation = "https://artursepp.github.io/TrendFollowingSystems/"
 Repository = "https://github.com/ArturSepp/TrendFollowingSystems"
 Issues = "https://github.com/ArturSepp/TrendFollowingSystems/issues"
 Changelog = "https://github.com/ArturSepp/TrendFollowingSystems/blob/main/CHANGELOG.md"

--- a/tests/test_docs_foundation.py
+++ b/tests/test_docs_foundation.py
@@ -51,6 +51,14 @@ def test_docs_extra_and_ignored_build_output_are_declared() -> None:
     assert "docs/_build/" in gitignore
 
 
+def test_public_entry_points_use_the_canonical_docs_url() -> None:
+    pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert f'Documentation = "{CANONICAL_DOCS_URL}"' in pyproject
+    assert f"]({CANONICAL_DOCS_URL})" in readme
+
+
 def test_robots_file_allows_crawling_and_names_the_canonical_sitemap() -> None:
     robots = (DOCS_ROOT / "robots.txt").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Records completion of Maintainer Gate A after the live Pages and Search Console checks.

- points project metadata and README to the deployed documentation root
- marks Gate A PASS and advances the roadmap to U3b
- guards the canonical public docs entry points

The redacted deployment/Search Console evidence remains in the required ignored agents report. Focused documentation and metadata tests: 12 passed.