### PR TITLE
Add wheel-tested root quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   package metadata.
 
 ### Added
+- Added `examples/quickstart.py` as the single offline, deterministic first-success source for
+  AR(1) and ARFIMA closed forms. The documentation includes that root file mechanically, and
+  tests execute it from an installed package without allowing output files or GUI access.
+- Added headless temporary-directory smoke tests for every claimed root example and documented
+  their environment, data boundary, runtime, output files, and compact expected results.
 - Added a dependency-free deployed-documentation audit that checks bounded HTTP fetches,
   redirects, canonical URLs, crawler directives, server-rendered content and navigation,
   internal task routes, required project links, `robots.txt`, and the generated sitemap.

--- a/README.md
+++ b/README.md
@@ -82,21 +82,19 @@ pip install -e ".[dev]"
 
 ## Quickstart
 
-The closed forms re-export at the package top level:
+The authoritative first-success script is
+[`examples/quickstart.py`](https://github.com/ArturSepp/TrendFollowingSystems/blob/main/examples/quickstart.py).
+It uses only the installed top-level API to compute deterministic AR(1) and ARFIMA closed forms:
 
-```python
-import trendfollowing as tf
-
-# closed-form Sharpe ratio of the European system under an AR-1 process
-sr = tf.sharpe_ar1(phi=0.05, long_span=21)                      # 0.336
-
-# the generic formula: any population autocorrelation function
-rho = tf.population_acf(n_lags=2000, phi=-0.05, d=0.1)          # ARFIMA(1,d,0)
-sr = tf.compute_annualised_sharpe(rho=rho, long_span=250, short_span=20)
-
-# the canonical realized-Sharpe estimator shared by all estimation layers
-sr_hat = tf.compute_realized_sharpe(returns=daily_returns, af=260.0)
+```console
+python examples/quickstart.py
 ```
+
+It prints the installed version, AR(1) Sharpe `0.200195`, ARFIMA(0,d,0) Sharpe `0.288820`, and
+the 260-day annualization, zero-drift, and single-EWMA conventions. It runs without network or
+data access, writes no files, and points to `PHI`, `D`, and `LONG_SPAN` as the first parameters
+to change. The [documentation quickstart](https://artursepp.github.io/TrendFollowingSystems/quickstart.html)
+includes the same file mechanically.
 
 A portfolio backtest of the paper's LS(250,20) filter on the packaged universe:
 

--- a/ROADMAP_DISCOVERABILITY_AND_ADOPTION.md
+++ b/ROADMAP_DISCOVERABILITY_AND_ADOPTION.md
@@ -6,8 +6,8 @@ Source: adapted from
 `C:\Users\artur\OneDrive\analytics\my_github\.agents\ROADMAP_OSS_DISCOVERABILITY_AND_ADOPTION.md`.
 
 Status: execution in progress. U0 and the public-data portion of U1 were recorded on 2026-08-16;
-M1, M2, U2, U3a, Maintainer Gate A, and U3b passed on 2026-08-16. The next implementation stage
-is U6.
+M1, M2, U2, U3a, Maintainer Gate A, U3b, and U6 passed on 2026-08-16. The next implementation
+stage is U4a.
 
 ## Outcome
 
@@ -603,6 +603,10 @@ claims.
 
 ## U6 — Create one root source of truth for first success
 
+**Execution status (2026-08-16): PASS.** The root quickstart, mechanical docs inclusion,
+headless example matrix, and clean-wheel execution passed. See
+`agents/U6_IMPLEMENTATION_REPORT.md`.
+
 **Deliverable:** `examples/quickstart.py` at repository root plus docs inclusion/drift checks.
 
 The script:
@@ -968,6 +972,7 @@ Use `PASS-LOCAL` only temporarily before required deployed checks, then replace 
 2026-08-16 · U3a · main@working-tree · PASS · warning-free HTML/linkcheck, static navigation, and Pages workflow passed
 2026-08-16 · Gate A · main@2e30bb5 · PASS · Pages, canonical GitHub identity, Search Console ownership, and sitemap submission completed
 2026-08-16 · U3b · main@working-tree · PASS · deployed HTTP, canonical, robots, sitemap, navigation, and outbound-route audit passed
+2026-08-16 · U6 · main@working-tree · PASS · root quickstart, docs drift guard, headless examples, and clean-wheel execution passed
 ```
 
 ## Definition of complete

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,18 +6,26 @@ Install the released package from PyPI:
 pip install trendfollowing
 ```
 
-Then evaluate the closed-form annualized Sharpe ratio of the European system under an
-AR(1) return process:
+Then run the authoritative offline example from a checkout or downloaded source tree:
 
-```python
-import trendfollowing as tf
-
-sharpe = tf.sharpe_ar1(phi=0.05, long_span=21)
-print(sharpe)
+```console
+python examples/quickstart.py
 ```
 
-The package supports Python 3.10 and newer and depends on `qis` for portfolio analytics
-and reporting. Continue with the
-[repository README](https://github.com/ArturSepp/TrendFollowingSystems/blob/main/README.md)
-for the generic autocorrelation formula and the packaged-universe backtest, or choose a
-maintained {doc}`workflow <workflows>`.
+The documentation includes that root script directly, so the runnable source and this page
+cannot silently drift:
+
+```{literalinclude} ../examples/quickstart.py
+:language: python
+:caption: examples/quickstart.py
+```
+
+The first line reports the installed package version. With the script's fixed parameters, the
+AR(1) annualized Sharpe is `0.200195` and the ARFIMA(0,d,0) annualized Sharpe is `0.288820`.
+Both are deterministic closed forms: they require no network or dataset, write no files, and
+open no GUI. The stated convention is 260 trading days per year, zero underlying drift, and a
+single 63-day EWMA filter. Change `PHI`, `D`, or `LONG_SPAN` first when exploring assumptions.
+
+The package supports Python 3.10 and newer and depends on `qis` for portfolio analytics and
+reporting. Continue with the {doc}`maintained example workflows <workflows>` for span selection,
+ACF prediction, and the packaged-universe backtest.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -6,24 +6,37 @@ without learning the package internals first.
 ## Compare Sharpe across filter spans
 
 [`examples/analytic_sharpe_vs_span.py`](https://github.com/ArturSepp/TrendFollowingSystems/blob/main/examples/analytic_sharpe_vs_span.py)
-compares the analytical Sharpe ratio across spans and process assumptions.
+compares the analytical Sharpe ratio across spans and process assumptions. It uses no data or
+network, takes about 3 seconds on the reference Python 3.12 environment, prints the gross/net
+span table, and writes `example_arfima_interior_optimum.png` to the current directory. The fixed
+case has its maximum net Sharpe of about `0.197` at the 42-day span.
 
 ## Predict Sharpe from an autocorrelation function
 
 [`examples/predict_sharpe_from_acf.py`](https://github.com/ArturSepp/TrendFollowingSystems/blob/main/examples/predict_sharpe_from_acf.py)
-shows how an estimated autocorrelation function enters the generic closed-form calculation.
+shows how an estimated autocorrelation function enters the generic closed-form calculation. It
+uses the futures data installed in the wheel, requires no network, takes about 18 seconds, and
+writes no files. The fixed four-contract output starts with ES1 predicted/realized Sharpe of
+approximately `0.227`/`0.206`.
 
 ## Backtest the European system
 
 [`examples/backtest_european_system.py`](https://github.com/ArturSepp/TrendFollowingSystems/blob/main/examples/backtest_european_system.py)
-runs the paper's European reference system using the futures data bundled with the package.
+runs the paper's European reference system using the futures data bundled with the package. It
+requires no network, takes about 24 seconds, prints the performance summary, and writes
+`example_european_backtest.png` to the current directory. The fixed LS(250,20) case reports
+Sharpe `1.095`, annualized volatility `0.152`, annualized return `0.166`, and maximum drawdown
+`-0.362`.
 
-Run an example from the repository root after a development install:
+The timings are observations from the 2026-08-16 Python 3.12 verification environment, not
+performance guarantees. Run an example from the repository root after a core install:
 
 ```console
-pip install -e ".[dev]"
+pip install trendfollowing
 python examples/analytic_sharpe_vs_span.py
 ```
 
-Examples may write ignored `example_*.png` figures to the working directory. For the full
-research workflow and its data boundary, use the {doc}`paper and replication map <paper>`.
+CI executes all three scripts with the non-interactive `Agg` backend from a temporary current
+directory. Generated `example_*.png` figures therefore remain isolated and are ignored in a
+development checkout. For the full research workflow and its data boundary, use the
+{doc}`paper and replication map <paper>`.

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,54 @@
+"""Offline first success with the trendfollowing public API.
+
+Run from any directory after installing the package:
+
+    python C:/path/to/TrendFollowingSystems/examples/quickstart.py
+
+The calculation uses no data or network access, writes no files, and opens no GUI.
+"""
+
+import trendfollowing as tf
+
+
+# First parameters to change when exploring process and filter assumptions.
+PHI = 0.05  # AR(1) coefficient of volatility-normalized daily returns.
+D = 0.02  # Fractional order of the ARFIMA(0,d,0) process.
+LONG_SPAN = 63  # Single-EWMA trend-filter span in trading days.
+N_LAGS = 1000  # Population ACF truncation used by the closed forms.
+
+# The paper uses 260 trading days per year. Both examples assume zero underlying drift.
+AF = float(tf.AF_DAILY)
+
+
+def main() -> None:
+    """Compute and print two deterministic closed-form Sharpe ratios."""
+
+    ar1_sharpe = tf.sharpe_ar1(
+        phi=PHI,
+        long_span=LONG_SPAN,
+        af=AF,
+        n_lags=N_LAGS,
+    )
+    arfima_sharpe = tf.sharpe_arfima(
+        d=D,
+        phi=0.0,
+        long_span=LONG_SPAN,
+        af=AF,
+        n_lags=N_LAGS,
+    )
+
+    print(f"trendfollowing {tf.__version__}")
+    print(
+        f"AR(1): phi={PHI:+.3f}, span={LONG_SPAN} days, "
+        f"annualized Sharpe={ar1_sharpe:.6f}"
+    )
+    print(
+        f"ARFIMA(0,d,0): d={D:.3f}, span={LONG_SPAN} days, "
+        f"annualized Sharpe={arfima_sharpe:.6f}"
+    )
+    print("Conventions: 260 trading days/year; zero underlying drift; one EWMA filter.")
+    print("Try next: change PHI, D, or LONG_SPAN near the top of examples/quickstart.py.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,88 @@
+"""Smoke and drift tests for the public root examples."""
+
+from importlib.metadata import version
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_ROOT = REPOSITORY_ROOT / "examples"
+QUICKSTART = EXAMPLES_ROOT / "quickstart.py"
+EXPECTED_QUICKSTART_LINES = (
+    "AR(1): phi=+0.050, span=63 days, annualized Sharpe=0.200195",
+    "ARFIMA(0,d,0): d=0.020, span=63 days, annualized Sharpe=0.288820",
+    "Conventions: 260 trading days/year; zero underlying drift; one EWMA filter.",
+    "Try next: change PHI, D, or LONG_SPAN near the top of examples/quickstart.py.",
+)
+CLAIMED_EXAMPLES = (
+    (
+        "analytic_sharpe_vs_span.py",
+        "gross    net",
+        {"example_arfima_interior_optimum.png"},
+    ),
+    ("predict_sharpe_from_acf.py", "ES1 Index", set()),
+    (
+        "backtest_european_system.py",
+        "sharpe       1.095",
+        {"example_european_backtest.png"},
+    ),
+)
+
+
+def _run_example(script: Path, working_directory: Path, timeout: float) -> tuple[str, float]:
+    environment = os.environ.copy()
+    environment["MPLBACKEND"] = "Agg"
+    started = time.perf_counter()
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=working_directory,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    )
+    return completed.stdout, time.perf_counter() - started
+
+
+def test_root_quickstart_is_the_single_documented_source(tmp_path: Path) -> None:
+    docs = (REPOSITORY_ROOT / "docs" / "quickstart.md").read_text(encoding="utf-8")
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert EXAMPLES_ROOT.is_dir()
+    assert QUICKSTART.is_file()
+    assert not (REPOSITORY_ROOT / "src" / "trendfollowing" / "examples").exists()
+    assert "{literalinclude} ../examples/quickstart.py" in docs
+    assert ":language: python" in docs
+    assert "examples/quickstart.py" in readme
+
+
+def test_quickstart_runs_offline_without_output_files(tmp_path: Path) -> None:
+    stdout, elapsed = _run_example(QUICKSTART, tmp_path, timeout=60.0)
+
+    assert stdout.splitlines()[0] == f"trendfollowing {version('trendfollowing')}"
+    for expected_line in EXPECTED_QUICKSTART_LINES:
+        assert expected_line in stdout
+    assert elapsed < 60.0
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_output", "expected_files"),
+    CLAIMED_EXAMPLES,
+)
+def test_claimed_examples_run_headlessly_from_temporary_directory(
+    filename: str,
+    expected_output: str,
+    expected_files: set[str],
+    tmp_path: Path,
+) -> None:
+    stdout, _ = _run_example(EXAMPLES_ROOT / filename, tmp_path, timeout=120.0)
+
+    assert expected_output in stdout
+    assert {path.name for path in tmp_path.iterdir()} == expected_files


### PR DESCRIPTION
Completes roadmap stage U6. Adds examples/quickstart.py as the single offline first-success source, includes it mechanically in the docs, replaces the README's undefined daily_returns block, documents every claimed example's environment/runtime/data/output contract, and runs all examples headlessly from temporary directories. Failure-first evidence: the prior README raised NameError; missing quickstart tests failed; a deliberate wrong Sharpe expectation failed before byte-for-byte restoration. Verification: root quickstart passed; example matrix 5 passed; independent Sharpe/resource tests 18 passed; metadata/docs tests 12 passed; Ruff passed; strict Sphinx HTML/linkcheck passed; a clean Python 3.12 environment imported the built wheel from site-packages and reproduced the deterministic output.