### PR TITLE
release: publish trendfollowing 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-17
+
 ### Changed
 - Pointed package metadata and the README documentation badge to the deployed
   canonical GitHub Pages site after Maintainer Gate A passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   on one public role and boundary. Installation now leads with
   `pip install trendfollowing`, and the documented `qis >= 5.0.9` floor matches
   package metadata.
+- Brought `src/trendfollowing`, tests, and root examples under the declared Ruff
+  E/F/W line-length gate. Intentional public re-export modules retain narrowly
+  scoped F401 exceptions; the formatting cleanup does not alter numerical results.
 
 ### Added
 - Added a dated, neutral package-choice guide comparing `trendfollowing` with pysystemtrade,
@@ -73,6 +76,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Replaced the stale literal `trendfollowing.__version__ == "1.0.0"` with the
   installed distribution version from `importlib.metadata`. An uninstalled
   direct source import reports `0+unknown` instead of inventing a release value.
+- Removed an undefined `credit_df` entry from maintainer-only data regeneration
+  and made screener figure output honor `TF_FIGURE_PATH`.
 
 ## [1.0.5] - 2026-08-01
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,8 @@ authors:
   - family-names: Lucic
     given-names: Vladimir
     affiliation: "Marex Solutions, London, and Imperial College London"
-version: 1.0.5
-date-released: "2026-08-01"
+version: 1.1.0
+date-released: "2026-08-17"
 license: GPL-3.0-or-later
 repository-code: "https://github.com/ArturSepp/TrendFollowingSystems"
 repository-artifact: "https://pypi.org/project/trendfollowing/"

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ should also cite the version it ran:
   author  = {Sepp, Artur and Lucic, Vladimir},
   title   = {trendfollowing},
   year    = {2026},
-  version = {1.0.5},
+  version = {1.1.0},
   url     = {https://github.com/ArturSepp/TrendFollowingSystems}
 }
 ```

--- a/docs/choosing_a_backtesting_tool.md
+++ b/docs/choosing_a_backtesting_tool.md
@@ -37,7 +37,7 @@ strategy types that `trendfollowing` intentionally does not implement.
 “Not identified” means that the capability was not found in the official sources audited for this
 page. It is not proof that no extension, user code, branch, or paid product can provide it.
 
-| Capability | `trendfollowing` 1.0.5 | pysystemtrade 1.8.2 | vectorbt 1.1.0 | Backtesting.py 0.6.6 |
+| Capability | `trendfollowing` 1.1.0 | pysystemtrade 1.8.2 | vectorbt 1.1.0 | Backtesting.py 0.6.6 |
 |---|---|---|---|---|
 | Primary design and audience | Research and replication library for closed-form trend-following analysis and maintained futures reference systems; not a broker or general execution engine. | Systematic-futures backtesting plus a production system for technically experienced users; the [repository][pst-repo] documents its scope and support expectations. | Matrix-oriented general strategy research for multi-asset and large parameter sweeps; see the [official feature list][vbt-repo]. | Compact, bar-by-bar entry/exit strategy testing and optimization for an individual tradeable asset; see the [official quickstart][bt-quickstart]. |
 | Closed-form trend-following moments | Expected return, volatility, Sharpe ratio, skewness, and turnover are package workflows; see {doc}`closed-form analytics <closed_form_analytics>`. | **Not identified** as a documented project capability in the [repository][pst-repo] or [backtesting guide][pst-backtesting]. | **Not identified** in the audited [community feature set][vbt-repo]. | **Not identified** in the audited [API][bt-api] and [quickstart][bt-quickstart]. |
@@ -104,7 +104,7 @@ from selection and recommendation.
 
 | Project | Version basis used here | Activity/source interpretation |
 |---|---|---|
-| `trendfollowing` | [1.0.5 on PyPI][tf-pypi], released 2026-08-01 | This documentation and the repository's tagged package metadata define the compared public contract. |
+| `trendfollowing` | [1.1.0 on PyPI][tf-pypi], released 2026-08-17 | This documentation and the repository's tagged package metadata define the compared public contract. |
 | pysystemtrade | [1.8.2 tagged release][pst-release], published 2024-11-06 | 1.8.2 is the latest official tagged release found. The project is not on PyPI; current capability links use the active official `develop` repository and documentation. The [repository history note][pst-repo] records the January 2026 move to `pst-group`. |
 | vectorbt | [1.1.0 on PyPI][vbt-pypi], released 2026-07-05 | The official community repository and its 1.1.0 package/release records define the compared scope; VectorBT PRO is not assessed. |
 | Backtesting.py | [0.6.6 on PyPI][bt-pypi], released 2026-07-22 | PyPI is the stable-version record used because the official [GitHub releases page][bt-releases] has no latest release object; current official docs and the repository define capabilities. |

--- a/examples/analytic_sharpe_vs_span.py
+++ b/examples/analytic_sharpe_vs_span.py
@@ -11,11 +11,13 @@ runs without any data
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from enum import Enum
+
 # trendfollowing
 from trendfollowing.analytics.autocorrelation import population_acf
 from trendfollowing.analytics.sharpe import compute_annualised_sharpe, compute_daily_moments
@@ -27,18 +29,25 @@ COST = 0.0020  # cost per unit of volatility-normalized turnover, 20bp
 SPANS = [5, 10, 21, 42, 63, 125, 250, 520]
 
 
-def compute_net_sharpe_by_span(phi: float = 0.0,
-                               d: float = 0.0,
-                               cost: float = COST,  # per unit of vol-normalized turnover
-                               spans: list = SPANS,
-                               ) -> pd.DataFrame:
+def compute_net_sharpe_by_span(
+    phi: float = 0.0,
+    d: float = 0.0,
+    cost: float = COST,  # per unit of vol-normalized turnover
+    spans: list = SPANS,
+) -> pd.DataFrame:
     """gross and net Sharpe ratios of the single-filter system across spans"""
     rho = population_acf(n_lags=2000, phi=phi, d=d)
     out = {}
     for span in spans:
-        gross = compute_annualised_sharpe(rho=rho, long_span=span, short_span=None, sr_underlying=0.0, af=AF)
-        _, var = compute_daily_moments(rho=rho, long_span=span, short_span=None, mean=0.0, variance=1.0)
-        turnover = expected_turnover(long_span=span, short_span=None, annualization_factor=AF, vol_target=VOL_TARGET)
+        gross = compute_annualised_sharpe(
+            rho=rho, long_span=span, short_span=None, sr_underlying=0.0, af=AF
+        )
+        _, var = compute_daily_moments(
+            rho=rho, long_span=span, short_span=None, mean=0.0, variance=1.0
+        )
+        turnover = expected_turnover(
+            long_span=span, short_span=None, annualization_factor=AF, vol_target=VOL_TARGET
+        )
         net = gross - cost * turnover / (VOL_TARGET * np.sqrt(var))
         out[span] = dict(gross=gross, net=net)
     return pd.DataFrame.from_dict(out, orient='index')
@@ -59,7 +68,11 @@ def run_local_test(local_test: LocalTests) -> None:
             table.columns = [f"{c}, phi={phi:+0.2f}" for c in table.columns]
             table.plot(ax=ax, marker='o')
         ax.axhline(0.0, color='black', lw=0.5)
-        ax.set_xscale('log'), ax.set_xlabel('signal span, days'), ax.set_ylabel('annualized Sharpe ratio')
+        (
+            ax.set_xscale('log'),
+            ax.set_xlabel('signal span, days'),
+            ax.set_ylabel('annualized Sharpe ratio'),
+        )
         ax.set_title('AR-1: the cost decides the sign of the short-memory alpha at every span')
         fig.savefig('example_ar1_knife_edge.png', dpi=150)
         print(compute_net_sharpe_by_span(phi=0.05).round(3))
@@ -72,8 +85,15 @@ def run_local_test(local_test: LocalTests) -> None:
             table = compute_net_sharpe_by_span(phi=phi, d=0.02)
             ax.plot(table.index, table['net'], marker='o', label=f"net, phi={phi:+0.2f}, d=0.02")
         ax.axhline(0.0, color='black', lw=0.5)
-        ax.set_xscale('log'), ax.set_xlabel('signal span, days'), ax.set_ylabel('annualized net Sharpe ratio')
-        ax.legend(), ax.set_title('ARFIMA: three cost-adjusted span-selection regimes in one figure')
+        (
+            ax.set_xscale('log'),
+            ax.set_xlabel('signal span, days'),
+            ax.set_ylabel('annualized net Sharpe ratio'),
+        )
+        (
+            ax.legend(),
+            ax.set_title('ARFIMA: three cost-adjusted span-selection regimes in one figure'),
+        )
         fig.savefig('example_arfima_interior_optimum.png', dpi=150)
         print(compute_net_sharpe_by_span(phi=0.0, d=0.02).round(3))
 

--- a/examples/backtest_european_system.py
+++ b/examples/backtest_european_system.py
@@ -6,11 +6,13 @@ uses only the dataset packaged in trendfollowing/resources
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from enum import Enum
+
 # qis / project
 import qis as qis
 from trendfollowing.universe import load_data
@@ -24,11 +26,15 @@ def summarize_nav(nav: pd.Series) -> pd.Series:
     """annualized performance summary of a compounded nav"""
     returns = nav.pct_change().dropna()
     drawdown = nav / nav.cummax() - 1.0
-    return pd.Series(dict(sharpe=float(compute_realized_sharpe(returns=returns, af=AF, ddof=1)),
-                          an_vol=np.sqrt(AF) * returns.std(),
-                          an_return=AF * returns.mean(),
-                          max_dd=drawdown.min()),
-                     name=nav.name)
+    return pd.Series(
+        dict(
+            sharpe=float(compute_realized_sharpe(returns=returns, af=AF, ddof=1)),
+            an_vol=np.sqrt(AF) * returns.std(),
+            an_return=AF * returns.mean(),
+            max_dd=drawdown.min(),
+        ),
+        name=nav.name,
+    )
 
 
 class LocalTests(Enum):
@@ -38,14 +44,16 @@ class LocalTests(Enum):
 def run_local_test(local_test: LocalTests) -> None:
     if local_test == LocalTests.PORTFOLIO_BACKTEST:
         prices, volume_costs, benchmark_prices, descriptive_df, group_order = load_data()
-        outputs = run_european_tf_system(prices=prices,
-                                         long_span=250,
-                                         short_span=20,  # the LS(250,20) filter of the paper
-                                         vol_span=33,  # volatility estimator span, days
-                                         portfolio_covar_span=63,  # activates portfolio-level volatility targeting
-                                         portfolio_target_vol=0.15,  # annualized portfolio volatility target
-                                         volume_costs=volume_costs,
-                                         warmup_period=250)
+        outputs = run_european_tf_system(
+            prices=prices,
+            long_span=250,
+            short_span=20,  # the LS(250,20) filter of the paper
+            vol_span=33,  # volatility estimator span, days
+            portfolio_covar_span=63,  # activates portfolio-level volatility targeting
+            portfolio_target_vol=0.15,  # annualized portfolio volatility target
+            volume_costs=volume_costs,
+            warmup_period=250,
+        )
         nav = outputs.portfolio_pnl_net.rename('European LS(250,20)').dropna()
         nav = nav[nav.ne(nav.iloc[0]).cummax()]  # start at the first active day after the warmup
         print(summarize_nav(nav=nav).round(3))

--- a/examples/predict_sharpe_from_acf.py
+++ b/examples/predict_sharpe_from_acf.py
@@ -10,11 +10,13 @@ uses only the dataset packaged in trendfollowing/resources
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 import pandas as pd
 from enum import Enum
 from typing import List
+
 # qis / project
 import qis as qis
 from trendfollowing.universe import load_data
@@ -27,9 +29,10 @@ WARMUP = 250  # days
 N_LAGS = 780
 
 
-def predict_and_realize(tickers: List[str],
-                        span: int = 63,  # signal span, days
-                        ) -> pd.DataFrame:
+def predict_and_realize(
+    tickers: List[str],
+    span: int = 63,  # signal span, days
+) -> pd.DataFrame:
     """closed-form prediction from sample moments against the realized gross backtest"""
     prices, volume_costs, benchmark_prices, descriptive_df, group_order = load_data()
     prices = prices[tickers].dropna(how='all')
@@ -42,12 +45,21 @@ def predict_and_realize(tickers: List[str],
         # sample inputs of the closed form
         rho = np.array([1.0] + [z.autocorr(lag=m) for m in range(1, N_LAGS)])
         mu_an = np.sqrt(AF) * z.mean() / z.std()
-        predicted = compute_annualised_sharpe(rho=rho, long_span=span, short_span=None,
-                                              sr_underlying=mu_an, af=AF)
+        predicted = compute_annualised_sharpe(
+            rho=rho, long_span=span, short_span=None, sr_underlying=mu_an, af=AF
+        )
         # realized gross backtest on the same sample
-        outputs = run_european_tf_system(prices=price.to_frame(), long_span=span, short_span=None,
-                                         vol_span=VOL_SPAN, volume_costs=0.0, warmup_period=WARMUP)
-        strategy_returns = outputs.portfolio_pnl.pct_change()  # portfolio_pnl is the compounded nav from 1.0
+        outputs = run_european_tf_system(
+            prices=price.to_frame(),
+            long_span=span,
+            short_span=None,
+            vol_span=VOL_SPAN,
+            volume_costs=0.0,
+            warmup_period=WARMUP,
+        )
+        strategy_returns = (
+            outputs.portfolio_pnl.pct_change()
+        )  # portfolio_pnl is the compounded nav from 1.0
         strategy_returns = strategy_returns[strategy_returns != 0.0]  # drop the flat warmup segment
         realized = float(compute_realized_sharpe(returns=strategy_returns, af=AF, ddof=1))
         rows[ticker] = dict(predicted=predicted, realized=float(realized))
@@ -60,7 +72,9 @@ class LocalTests(Enum):
 
 def run_local_test(local_test: LocalTests) -> None:
     if local_test == LocalTests.PREDICT_CORE_CONTRACTS:
-        table = predict_and_realize(tickers=['ES1 Index', 'TY1 Comdty', 'GC1 Comdty', 'C 1 Comdty'], span=63)
+        table = predict_and_realize(
+            tickers=['ES1 Index', 'TY1 Comdty', 'GC1 Comdty', 'C 1 Comdty'], span=63
+        )
         print(table.round(3))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,11 @@ line-length = 100
 # stack before the project packages, which isort reorders.
 select = ["E", "F", "W"]
 
+[tool.ruff.lint.per-file-ignores]
+# These modules exist to re-export their imported symbols as the documented public API.
+"src/trendfollowing/__init__.py" = ["F401"]
+"src/trendfollowing/analytics/__init__.py" = ["F401"]
+
 [tool.coverage.run]
 source = ["src/trendfollowing"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trendfollowing"
-version = "1.0.5"
+version = "1.1.0"
 description = "trendfollowing — closed-form trend-following analytics, reference system implementations, and reproducible futures evidence in Python for quantitative researchers and practitioners."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/trendfollowing/analysis/autocorr_analysis.py
+++ b/src/trendfollowing/analysis/autocorr_analysis.py
@@ -4,6 +4,7 @@ per-group acf estimates and plots behind the autocorrelation exhibits of the pap
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 import pandas as pd
@@ -24,48 +25,54 @@ from futures_strats.data.universes.futures.bbg_futures import Universes
 from futures_strats.local_path import LOCAL_PATH
 
 
-def compute_returns_autocorrelation(prices: Union[pd.DataFrame, pd.Series],
-                                    freq: str = 'B',
-                                    span: int = 31,
-                                    autocorr_span: int = 31,
-                                    is_ra_returns: bool = False
-                                    ) -> Union[pd.DataFrame, pd.Series]:
-
+def compute_returns_autocorrelation(
+    prices: Union[pd.DataFrame, pd.Series],
+    freq: str = 'B',
+    span: int = 31,
+    autocorr_span: int = 31,
+    is_ra_returns: bool = False,
+) -> Union[pd.DataFrame, pd.Series]:
     """
     sample acf of log returns per instrument at the given lags
     """
     if isinstance(prices, pd.Series):
         prices = prices.to_frame()
     returns_1 = qis.to_returns(prices=prices, is_log_returns=True, freq=None, drop_first=True)
-    autocorr_df = qis.ewm_xy_convolution(returns=returns_1,
-                                         freq=freq,
-                                         convolution_type=qis.ConvolutionType.AUTO_CORR,
-                                         is_ra_returns=is_ra_returns)
+    autocorr_df = qis.ewm_xy_convolution(
+        returns=returns_1,
+        freq=freq,
+        convolution_type=qis.ConvolutionType.AUTO_CORR,
+        is_ra_returns=is_ra_returns,
+    )
     return autocorr_df
 
 
-def compute_returns_autocorrelation0(prices: Union[pd.DataFrame, pd.Series],
-                                    freq: str = 'B',
-                                    span: int = 31,
-                                    autocorr_span: int = 31,
-                                    is_ra_returns: bool = False
-                                    ) -> Union[pd.DataFrame, pd.Series]:
+def compute_returns_autocorrelation0(
+    prices: Union[pd.DataFrame, pd.Series],
+    freq: str = 'B',
+    span: int = 31,
+    autocorr_span: int = 31,
+    is_ra_returns: bool = False,
+) -> Union[pd.DataFrame, pd.Series]:
     """
     sample acf of log returns per instrument, legacy variant kept for comparison
     """
     if is_ra_returns:
         returns_1 = qis.to_returns(prices=prices, is_log_returns=True, freq=None, drop_first=True)
-        returns = qis.compute_sum_freq_ra_returns(returns=returns_1, freq=freq, span=span,
-                                                  is_log_returns_to_arithmetic=False,
-                                                  is_norm=False,
-                                                  warmup_period=100)
+        returns = qis.compute_sum_freq_ra_returns(
+            returns=returns_1,
+            freq=freq,
+            span=span,
+            is_log_returns_to_arithmetic=False,
+            is_norm=False,
+            warmup_period=100,
+        )
     else:
         returns = qis.to_returns(prices=prices, is_log_returns=True, freq=freq, drop_first=True)
 
-    autocorr_df = qis.compute_ewm_vector_autocorr_df(data=returns,
-                                                     span=autocorr_span,
-                                                     lag=1,
-                                                     is_normalize=True)
+    autocorr_df = qis.compute_ewm_vector_autocorr_df(
+        data=returns, span=autocorr_span, lag=1, is_normalize=True
+    )
     return autocorr_df
 
 
@@ -83,13 +90,13 @@ def get_prices(time_period: da.TimePeriod = None) -> Tuple[Dict, pd.Series]:
     return ac_prices, ac_data
 
 
-def plot_instrument_acf(price: pd.Series,
-                        freqs: List[str] = ('B', 'W-MON', 'ME', 'QE'),
-                        ra_spans: List[int] = (2.5, 5, 21, 63),
-                        nlags: int = 20,
-                        is_ra_returns: bool = False
-                        ):
-
+def plot_instrument_acf(
+    price: pd.Series,
+    freqs: List[str] = ('B', 'W-MON', 'ME', 'QE'),
+    ra_spans: List[int] = (2.5, 5, 21, 63),
+    nlags: int = 20,
+    is_ra_returns: bool = False,
+):
     """
     plot the sample acf and pacf bars of one instrument's returns
     """
@@ -98,35 +105,48 @@ def plot_instrument_acf(price: pd.Series,
         axs = qis.to_flat_list(axs)
 
         for idx, freq in enumerate(freqs):
-            returns_1 = qis.to_returns(prices=price, is_log_returns=True, freq=None, drop_first=True)
+            returns_1 = qis.to_returns(
+                prices=price, is_log_returns=True, freq=None, drop_first=True
+            )
             if is_ra_returns:
-                returns = qis.compute_sum_freq_ra_returns(returns=returns_1, freq=freq, span=ra_spans[idx],
-                                                          is_log_returns_to_arithmetic=False,
-                                                          is_norm=False)
+                returns = qis.compute_sum_freq_ra_returns(
+                    returns=returns_1,
+                    freq=freq,
+                    span=ra_spans[idx],
+                    is_log_returns_to_arithmetic=False,
+                    is_norm=False,
+                )
             else:
-                returns = qis.to_returns(prices=price, is_log_returns=True, freq=freq, drop_first=True)
+                returns = qis.to_returns(
+                    prices=price, is_log_returns=True, freq=freq, drop_first=True
+                )
 
             acfs, pacfs = qis.estimate_acf_from_path(path=returns, nlags=nlags)
-            qis.plot_bars(df=acfs,
-                          title=f"Returns frequency={freq}",
-                          legend_loc=None,
-                          x_rotation=0,
-                          xlabel='lag',
-                          ax=axs[idx])
+            qis.plot_bars(
+                df=acfs,
+                title=f"Returns frequency={freq}",
+                legend_loc=None,
+                x_rotation=0,
+                xlabel='lag',
+                ax=axs[idx],
+            )
             ax = axs[idx]
             n_error = 1.0 / np.sqrt(len(returns.index))
             ax.axhline(n_error, color='red', linestyle='dashed', linewidth=1)
             ax.axhline(-n_error, color='red', linestyle='dashed', linewidth=1)
-            qis.set_suptitle(fig, title=f"Autocorrelation of {price.name}: {qis.get_time_period(df=price).to_str()}")
+            qis.set_suptitle(
+                fig,
+                title=f"Autocorrelation of {price.name}: {qis.get_time_period(df=price).to_str()}",
+            )
 
 
-def plot_instrument_acf_ewm(prices: Union[pd.Series, pd.DataFrame],
-                            freqs: List[str] = ('B', 'W-MON', 'ME', 'QE'),
-                            ra_span: int = 31,
-                            autocorr_spans: List[int] = (10*260, 10*52, 10*12, 10*4),
-                            is_ra_returns: bool = False
-                            ):
-
+def plot_instrument_acf_ewm(
+    prices: Union[pd.Series, pd.DataFrame],
+    freqs: List[str] = ('B', 'W-MON', 'ME', 'QE'),
+    ra_span: int = 31,
+    autocorr_spans: List[int] = (10 * 260, 10 * 52, 10 * 12, 10 * 4),
+    is_ra_returns: bool = False,
+):
     """
     plot the ewm-smoothed acf of instrument returns across lags
     """
@@ -135,35 +155,38 @@ def plot_instrument_acf_ewm(prices: Union[pd.Series, pd.DataFrame],
         axs = qis.to_flat_list(axs)
 
         for idx, freq in enumerate(freqs):
-            autocorr_df = compute_returns_autocorrelation(prices=prices,
-                                                          freq=freq,
-                                                          span=ra_span,
-                                                          autocorr_span=autocorr_spans[idx],
-                                                          is_ra_returns=is_ra_returns)
+            autocorr_df = compute_returns_autocorrelation(
+                prices=prices,
+                freq=freq,
+                span=ra_span,
+                autocorr_span=autocorr_spans[idx],
+                is_ra_returns=is_ra_returns,
+            )
             if isinstance(prices, pd.DataFrame) and len(prices.columns) > 10:
                 legend_loc = None
             else:
                 legend_loc = 'upper left'
-            qis.plot_time_series(df=autocorr_df,
-                                 title=f"Returns frequency={freq}",
-                                 x_date_freq='YE',
-                                 date_format='%d-%b-%y',
-                                 legend_loc=legend_loc,
-                                 ax=axs[idx])
+            qis.plot_time_series(
+                df=autocorr_df,
+                title=f"Returns frequency={freq}",
+                x_date_freq='YE',
+                date_format='%d-%b-%y',
+                legend_loc=legend_loc,
+                ax=axs[idx],
+            )
             ax = axs[idx]
             n_error = 1.0 / np.sqrt(autocorr_spans[idx])
             ax.axhline(n_error, color='red', linestyle='dashed', linewidth=1)
             ax.axhline(-n_error, color='red', linestyle='dashed', linewidth=1)
 
 
-
-def plot_group_acf_ewm(prices: pd.DataFrame,
-                       freqs: List[str] = ('B', 'W-MON', 'ME', 'QE'),
-                       ra_span: int = 31,
-                       autocorr_spans: List[int] = (10*260, 10*52, 10*12, 10*4),
-                       is_ra_returns: bool = False
-                       ) -> plt.Figure:
-
+def plot_group_acf_ewm(
+    prices: pd.DataFrame,
+    freqs: List[str] = ('B', 'W-MON', 'ME', 'QE'),
+    ra_span: int = 31,
+    autocorr_spans: List[int] = (10 * 260, 10 * 52, 10 * 12, 10 * 4),
+    is_ra_returns: bool = False,
+) -> plt.Figure:
     """
     plot the ewm-smoothed acf aggregated by asset group
     """
@@ -172,24 +195,33 @@ def plot_group_acf_ewm(prices: pd.DataFrame,
         axs = qis.to_flat_list(axs)
 
         for idx, freq in enumerate(freqs):
-            autocorr_df = compute_returns_autocorrelation(prices=prices,
-                                                          freq=freq,
-                                                          span=ra_span,
-                                                          autocorr_span=autocorr_spans[idx],
-                                                          is_ra_returns=is_ra_returns)
+            autocorr_df = compute_returns_autocorrelation(
+                prices=prices,
+                freq=freq,
+                span=ra_span,
+                autocorr_span=autocorr_spans[idx],
+                is_ra_returns=is_ra_returns,
+            )
             autocorr_df = autocorr_df.replace({0.0: np.nan})
-            df = pd.concat([autocorr_df.quantile(q=0.25, axis=1).rename('25% Quantile'),
-                            autocorr_df.median(axis=1).rename('Median'),
-                            autocorr_df.quantile(q=0.75, axis=1).rename('75% Quantile')],
-                           axis=1, sort=False)
+            df = pd.concat(
+                [
+                    autocorr_df.quantile(q=0.25, axis=1).rename('25% Quantile'),
+                    autocorr_df.median(axis=1).rename('Median'),
+                    autocorr_df.quantile(q=0.75, axis=1).rename('75% Quantile'),
+                ],
+                axis=1,
+                sort=False,
+            )
 
-            qis.plot_time_series(df=df,
-                                 title=f"Returns frequency={freq}",
-                                 x_date_freq='YE',
-                                 date_format='%d-%b-%y',
-                                 framealpha=0.9,
-                                 trend_line=qis.TrendLine.ZERO_SHADOWS,
-                                 ax=axs[idx])
+            qis.plot_time_series(
+                df=df,
+                title=f"Returns frequency={freq}",
+                x_date_freq='YE',
+                date_format='%d-%b-%y',
+                framealpha=0.9,
+                trend_line=qis.TrendLine.ZERO_SHADOWS,
+                ax=axs[idx],
+            )
             ax = axs[idx]
             n_error = 1.0 / np.sqrt(autocorr_spans[idx])
             ax.axhline(n_error, color='red', linestyle='dashed', linewidth=1)
@@ -214,7 +246,9 @@ def plot_acf(time_period: da.TimePeriod = None):
         box.df_boxplot_by_index(df=ac_acfs, ax=axs)
 
     returns = ret.to_returns(prices=ac_prices['Universe'], freq=freq)
-    returns, weights, _ = tra.compute_ra_returns(returns=ret.to_returns(prices=ac_prices['Universe'],is_first_zero=True), ewm_lambda=0.94)
+    returns, weights, _ = tra.compute_ra_returns(
+        returns=ret.to_returns(prices=ac_prices['Universe'], is_first_zero=True), ewm_lambda=0.94
+    )
     # returns = returns.resample('QE').sum().iloc[1:, :]
     print(returns)
 
@@ -246,6 +280,7 @@ def run_local_test(local_test: LocalTests):
     """
 
     from futures_strats.local_path import LOCAL_PATH
+
     universe_data = Universes.BBG_FUTURES.load_universe_data(local_path=LOCAL_PATH)
     prices = universe_data.get_prices(freq='B').ffill()
     time_period = da.TimePeriod('31Dec1990', None)
@@ -283,7 +318,6 @@ def run_local_test(local_test: LocalTests):
 
 
 if __name__ == '__main__':
-
     local_test = LocalTests.TIME_SERIES_AUTOCORR
 
 run_local_test(local_test=local_test)

--- a/src/trendfollowing/analysis/signal_plots.py
+++ b/src/trendfollowing/analysis/signal_plots.py
@@ -1,8 +1,8 @@
 """
 illustration of signal plots
 """
+
 import pandas as pd
-import os
 import numpy as np
 import qis as qis
 import seaborn as sns
@@ -12,7 +12,11 @@ from enum import Enum
 
 # my projects
 from trendfollowing.systems.backtest_utils import compute_vol_norm_returns
-from trendfollowing.systems.european import compute_tf_signal_weight, compute_tf_signal, compute_tf_strat_pnl
+from trendfollowing.systems.european import (
+    compute_tf_signal_weight,
+    compute_tf_signal,
+    compute_tf_strat_pnl,
+)
 
 
 def plot_vol_norm_returns(returns_dict: Dict[str, pd.Series], vol_span: int = 31) -> plt.Figure:
@@ -23,20 +27,25 @@ def plot_vol_norm_returns(returns_dict: Dict[str, pd.Series], vol_span: int = 31
         fig, axs = plt.subplots(len(returns_dict.keys()), 2, figsize=(15, 12), tight_layout=True)
         axs = qis.to_flat_list(axs)
         for idx, (key, returns) in enumerate(returns_dict.items()):
-            vol_norm_returns = compute_vol_norm_returns(returns=returns.to_numpy(), vol_span=vol_span)
+            vol_norm_returns = compute_vol_norm_returns(
+                returns=returns.to_numpy(), vol_span=vol_span
+            )
             vol_norm_returns = pd.Series(vol_norm_returns, index=returns.index, name=key)
-            qis.plot_time_series(df=vol_norm_returns, title=f"{key} vol normalised returns",
-                                 ax=axs[2*idx])
-            qis.plot_histogram(df=vol_norm_returns, title=f"{key} vol normalised returns",
-                               ax=axs[2*idx+1])
+            qis.plot_time_series(
+                df=vol_norm_returns, title=f"{key} vol normalised returns", ax=axs[2 * idx]
+            )
+            qis.plot_histogram(
+                df=vol_norm_returns, title=f"{key} vol normalised returns", ax=axs[2 * idx + 1]
+            )
     return fig
 
 
-def plot_signal(returns_dict: Dict[str, pd.Series],
-                long_span: int = 31,
-                short_span: Optional[int] = None,
-                vol_span: int = 31
-                ) -> plt.Figure:
+def plot_signal(
+    returns_dict: Dict[str, pd.Series],
+    long_span: int = 31,
+    short_span: Optional[int] = None,
+    vol_span: int = 31,
+) -> plt.Figure:
     """
     plot the ewma tf signal of the given instruments
     """
@@ -44,21 +53,25 @@ def plot_signal(returns_dict: Dict[str, pd.Series],
         fig, axs = plt.subplots(len(returns_dict.keys()), 2, figsize=(15, 12), tight_layout=True)
         axs = qis.to_flat_list(axs)
         for idx, (key, returns) in enumerate(returns_dict.items()):
-            tf_signal = compute_tf_signal(returns=returns.to_numpy(), long_span=long_span, short_span=short_span, vol_span=vol_span)
+            tf_signal = compute_tf_signal(
+                returns=returns.to_numpy(),
+                long_span=long_span,
+                short_span=short_span,
+                vol_span=vol_span,
+            )
             tf_signal = pd.Series(tf_signal, index=returns.index, name=key)
-            qis.plot_time_series(df=tf_signal, title=f"{key} signal",
-                                 ax=axs[2*idx])
-            qis.plot_histogram(df=tf_signal, title=f"{key} signal",
-                               ax=axs[2*idx+1])
+            qis.plot_time_series(df=tf_signal, title=f"{key} signal", ax=axs[2 * idx])
+            qis.plot_histogram(df=tf_signal, title=f"{key} signal", ax=axs[2 * idx + 1])
     return fig
 
 
-def plot_signal_weight(returns_dict: Dict[str, pd.Series],
-                       long_span: int = 31,
-                       short_span: Optional[int] = None,
-                       vol_span: int = 33,
-                       vol_target: float = 0.3
-                       ) -> plt.Figure:
+def plot_signal_weight(
+    returns_dict: Dict[str, pd.Series],
+    long_span: int = 31,
+    short_span: Optional[int] = None,
+    vol_span: int = 33,
+    vol_target: float = 0.3,
+) -> plt.Figure:
     """
     plot the signal and the volatility-target weight of the given instruments
     """
@@ -66,23 +79,26 @@ def plot_signal_weight(returns_dict: Dict[str, pd.Series],
         fig, axs = plt.subplots(len(returns_dict.keys()), 2, figsize=(15, 12), tight_layout=True)
         axs = qis.to_flat_list(axs)
         for idx, (key, returns) in enumerate(returns_dict.items()):
-            tf_signal_weight, signals, vols = compute_tf_signal_weight(returns=returns.to_numpy(), long_span=long_span,
-                                                                       short_span=short_span, vol_span=vol_span,
-                                                                       vol_target=vol_target)
+            tf_signal_weight, signals, vols = compute_tf_signal_weight(
+                returns=returns.to_numpy(),
+                long_span=long_span,
+                short_span=short_span,
+                vol_span=vol_span,
+                vol_target=vol_target,
+            )
             tf_signal_weight = pd.Series(tf_signal_weight, index=returns.index, name=key)
-            qis.plot_time_series(df=tf_signal_weight, title=f"{key} signal",
-                                 ax=axs[2*idx])
-            qis.plot_histogram(df=tf_signal_weight, title=f"{key} signal",
-                               ax=axs[2*idx+1])
+            qis.plot_time_series(df=tf_signal_weight, title=f"{key} signal", ax=axs[2 * idx])
+            qis.plot_histogram(df=tf_signal_weight, title=f"{key} signal", ax=axs[2 * idx + 1])
     return fig
 
 
-def plot_strat_pnl(returns_dict: Dict[str, pd.Series],
-                   long_span: int = 31,
-                   short_span: Optional[int] = None,
-                   vol_span: int = 33,
-                   vol_target: float = 0.3
-                   ) -> plt.Figure:
+def plot_strat_pnl(
+    returns_dict: Dict[str, pd.Series],
+    long_span: int = 31,
+    short_span: Optional[int] = None,
+    vol_span: int = 33,
+    vol_target: float = 0.3,
+) -> plt.Figure:
     """
     plot the strategy pnl of the given instruments under the ewma signal
     """
@@ -90,14 +106,16 @@ def plot_strat_pnl(returns_dict: Dict[str, pd.Series],
         fig, axs = plt.subplots(len(returns_dict.keys()), 2, figsize=(15, 12), tight_layout=True)
         axs = qis.to_flat_list(axs)
         for idx, (key, returns) in enumerate(returns_dict.items()):
-            pnl, weights, vols = compute_tf_strat_pnl(returns=returns.to_numpy(), long_span=long_span, short_span=short_span,
-                                          vol_span=vol_span,
-                                          vol_target=vol_target)
+            pnl, weights, vols = compute_tf_strat_pnl(
+                returns=returns.to_numpy(),
+                long_span=long_span,
+                short_span=short_span,
+                vol_span=vol_span,
+                vol_target=vol_target,
+            )
             pnl = pd.Series(pnl, index=returns.index, name=key)
-            qis.plot_time_series(df=pnl, title=f"{key} cum p&l",
-                                 ax=axs[2*idx])
-            qis.plot_histogram(df=pnl.diff(1), title=f"{key} daily p&l",
-                               ax=axs[2*idx+1])
+            qis.plot_time_series(df=pnl, title=f"{key} cum p&l", ax=axs[2 * idx])
+            qis.plot_histogram(df=pnl.diff(1), title=f"{key} daily p&l", ax=axs[2 * idx + 1])
     return fig
 
 
@@ -108,7 +126,9 @@ def check_filter_span(returns: pd.Series, long_span: int = 100, short_span: int 
     long_spans = np.linspace(100, 1000, 10)
     signals = {}
     for long_span in long_spans:
-        signals[f"span={long_span}"] = qis.compute_ewm_long_short_filter(data=returns, long_span=long_span, short_span=None)
+        signals[f"span={long_span}"] = qis.compute_ewm_long_short_filter(
+            data=returns, long_span=long_span, short_span=None
+        )
     signals = pd.DataFrame.from_dict(signals, orient='columns')
     with sns.axes_style("darkgrid"):
         fig, ax = plt.subplots(1, 1, figsize=(15, 12), tight_layout=True)
@@ -119,8 +139,12 @@ def check_long_short_filters(returns: pd.DataFrame, long_span: int = 100, short_
     """
     visual check of the long-short filter combinations on a return panel
     """
-    signal_unit = qis.compute_ewm_long_short_filter(data=returns, long_span=long_span, short_span=None)
-    signal_2 = qis.compute_ewm_long_short_filter(data=returns, long_span=long_span, short_span=short_span)
+    signal_unit = qis.compute_ewm_long_short_filter(
+        data=returns, long_span=long_span, short_span=None
+    )
+    signal_2 = qis.compute_ewm_long_short_filter(
+        data=returns, long_span=long_span, short_span=short_span
+    )
 
     with sns.axes_style("darkgrid"):
         fig, axs = plt.subplots(1, 2, figsize=(15, 12), tight_layout=True)
@@ -143,6 +167,7 @@ def run_local_test(local_test: LocalTests):
     Use for quick verification during development.
     """
     from trendfollowing.local_path import get_universe_data_path
+
     local_path = get_universe_data_path()
 
     prices = qis.load_df_from_csv(file_name='bbg_futures_close', local_path=local_path)
@@ -151,50 +176,51 @@ def run_local_test(local_test: LocalTests):
     returns = qis.to_returns(prices=prices)
 
     if local_test == LocalTests.PLOT_VOL_NORM_RETURNS:
-        returns_dict = {'S&P 500': returns['ES1 Index'].dropna(), 'UST10Y': returns['TY1 Comdty'].dropna()}
+        returns_dict = {
+            'S&P 500': returns['ES1 Index'].dropna(),
+            'UST10Y': returns['TY1 Comdty'].dropna(),
+        }
         print(returns_dict)
         plot_vol_norm_returns(returns_dict=returns_dict)
 
     elif local_test == LocalTests.PLOT_SIGNAL:
-        returns_dict = {'S&P 500': returns['ES1 Index'].dropna(), 'UST10Y': returns['TY1 Comdty'].dropna()}
+        returns_dict = {
+            'S&P 500': returns['ES1 Index'].dropna(),
+            'UST10Y': returns['TY1 Comdty'].dropna(),
+        }
         print(returns_dict)
-        plot_signal(returns_dict=returns_dict,
-                    long_span=100,
-                    short_span=None,
-                    vol_span=31)
+        plot_signal(returns_dict=returns_dict, long_span=100, short_span=None, vol_span=31)
 
     elif local_test == LocalTests.PLOT_SIGNAL_WEIGHT:
-        returns_dict = {'S&P 500': returns['ES1 Index'].dropna(), 'UST10Y': returns['TY1 Comdty'].dropna()}
+        returns_dict = {
+            'S&P 500': returns['ES1 Index'].dropna(),
+            'UST10Y': returns['TY1 Comdty'].dropna(),
+        }
         print(returns_dict)
-        plot_signal_weight(returns_dict=returns_dict,
-                           long_span=100,
-                           short_span=None,
-                           vol_span=31)
+        plot_signal_weight(returns_dict=returns_dict, long_span=100, short_span=None, vol_span=31)
 
     elif local_test == LocalTests.PLOT_PNL:
-        returns_dict = {'S&P 500': returns['ES1 Index'].dropna(), 'UST10Y': returns['TY1 Comdty'].dropna()}
+        returns_dict = {
+            'S&P 500': returns['ES1 Index'].dropna(),
+            'UST10Y': returns['TY1 Comdty'].dropna(),
+        }
         print(returns_dict)
-        plot_strat_pnl(returns_dict=returns_dict,
-                       long_span=250,
-                       short_span=20,
-                       vol_span=31)
+        plot_strat_pnl(returns_dict=returns_dict, long_span=250, short_span=20, vol_span=31)
 
     elif local_test == LocalTests.CHECK_SIGNAL:
-
         # signals = compute_tf_signal(returns=returns.to_numpy(), tf_span=120)
-        #signals = pd.DataFrame(signals, index=returns.index, columns=returns.columns)
-        #qis.plot_histogram(df=signals)
+        # signals = pd.DataFrame(signals, index=returns.index, columns=returns.columns)
+        # qis.plot_histogram(df=signals)
 
         returns = pd.DataFrame(np.random.normal(loc=0.0, scale=0.2, size=(100000, 30)))
         ra_returns, _, _ = qis.compute_ra_returns(returns=returns)
-        #check_long_short_filters(returns=ra_returns)
+        # check_long_short_filters(returns=ra_returns)
 
         check_filter_span(returns=ra_returns.iloc[:, 0])
     plt.show()
 
 
 if __name__ == '__main__':
-
     local_test = LocalTests.PLOT_PNL
 
     run_local_test(local_test=local_test)

--- a/src/trendfollowing/analysis/tf_signal_screener.py
+++ b/src/trendfollowing/analysis/tf_signal_screener.py
@@ -3,6 +3,7 @@ screener for TF signal
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 import os
 import numpy as np
 import pandas as pd
@@ -15,19 +16,19 @@ from typing import List
 from enum import Enum
 
 from trendfollowing.systems.american import run_american_system
-from trendfollowing.systems.european import run_european_tf_system, compute_tf_signal
-from trendfollowing.systems.tsmom import run_tsmom_system
-from trendfollowing.systems.backtest_utils import compute_vol, BacktestOutputs, compute_vol_target_weight
+from trendfollowing.systems.european import compute_tf_signal
+from trendfollowing.systems.backtest_utils import compute_vol
 
 
-def run_european_screener(prices: pd.DataFrame,
-                          group_data: pd.Series,
-                          group_order: List[str],
-                          long_span: int = 250,
-                          short_span: int = 20,
-                          vol_span: int = 33,
-                          window: int = 10
-                          ):
+def run_european_screener(
+    prices: pd.DataFrame,
+    group_data: pd.Series,
+    group_order: List[str],
+    long_span: int = 250,
+    short_span: int = 20,
+    vol_span: int = 33,
+    window: int = 10,
+):
     """
     backtest_outputs = run_european_tf_system(prices=prices,
                                               long_span=long_span,
@@ -37,46 +38,59 @@ def run_european_screener(prices: pd.DataFrame,
                                               portfolio_covar_span=None,
                                               volume_costs=volume_costs)
     """
-    backtest_outputs = run_american_system(prices=prices,
-                                           long_span=long_span,
-                                           short_span=short_span,
-                                           vol_span=vol_span,
-                                           stop_loss_atr_multiplier=10.0,
-                                           signal_atr_multiplier=5.0,
-                                           portfolio_covar_span=None,
-                                           volume_costs=0.0)
+    backtest_outputs = run_american_system(
+        prices=prices,
+        long_span=long_span,
+        short_span=short_span,
+        vol_span=vol_span,
+        stop_loss_atr_multiplier=10.0,
+        signal_atr_multiplier=5.0,
+        portfolio_covar_span=None,
+        volume_costs=0.0,
+    )
     am_position = np.sign(backtest_outputs.weights)
 
     returns = qis.to_returns(prices, is_log_returns=True, is_first_zero=False)
 
-    next_periods = pd.date_range(start=returns.index[-1] + pd.DateOffset(days=1), periods=window, freq='1d')
-    returns_next_periods = pd.concat([returns, pd.DataFrame(0.0, columns=returns.columns, index=next_periods)], axis=0)
-    returns_next_periods = returns_next_periods.iloc[window:, :] # align shape
+    next_periods = pd.date_range(
+        start=returns.index[-1] + pd.DateOffset(days=1), periods=window, freq='1d'
+    )
+    returns_next_periods = pd.concat(
+        [returns, pd.DataFrame(0.0, columns=returns.columns, index=next_periods)], axis=0
+    )
+    returns_next_periods = returns_next_periods.iloc[window:, :]  # align shape
 
     returns_np = returns.to_numpy()
     returns_next_periods_np = returns_next_periods.to_numpy()
     vols_current = compute_vol(returns=returns_np, vol_span=vol_span, is_lag1=True)
-    vols_predicted = compute_vol(returns=returns_np, vol_span=vol_span, is_lag1=True)
 
     vol_norm_returns_current = returns_np / vols_current
     vol_norm_returns_predicted = returns_next_periods_np / vols_current
 
-    signal_current = compute_tf_signal(returns=returns_np,
-                                       vol_norm_returns=vol_norm_returns_current,
-                                       long_span=long_span,
-                                       short_span=short_span,
-                                       vol_span=vol_span)
-    signal_predicted = compute_tf_signal(returns=returns_next_periods_np,
-                                         vol_norm_returns=vol_norm_returns_predicted,
-                                         long_span=long_span,
-                                         short_span=short_span,
-                                         vol_span=vol_span)
+    signal_current = compute_tf_signal(
+        returns=returns_np,
+        vol_norm_returns=vol_norm_returns_current,
+        long_span=long_span,
+        short_span=short_span,
+        vol_span=vol_span,
+    )
+    signal_predicted = compute_tf_signal(
+        returns=returns_next_periods_np,
+        vol_norm_returns=vol_norm_returns_predicted,
+        long_span=long_span,
+        short_span=short_span,
+        vol_span=vol_span,
+    )
     df = pd.DataFrame(signal_current, columns=returns.columns, index=returns.index)
-    df_predicted = pd.DataFrame(signal_predicted, columns=returns_next_periods.columns, index=returns_next_periods.index)
+    df_predicted = pd.DataFrame(
+        signal_predicted, columns=returns_next_periods.columns, index=returns_next_periods.index
+    )
 
     # df = backtest_outputs.signals
     dfs = qis.split_df_by_groups(df=df, group_data=group_data, group_order=group_order)
-    dfs_predicted = qis.split_df_by_groups(df=df_predicted, group_data=group_data, group_order=group_order)
+    dfs_predicted = qis.split_df_by_groups(
+        df=df_predicted, group_data=group_data, group_order=group_order
+    )
 
     joint = []
     colors = get_n_colors(n=len(dfs.keys()))
@@ -84,7 +98,7 @@ def run_european_screener(prices: pd.DataFrame,
     for idx, (key, df) in enumerate(dfs.items()):
         df_1 = df.iloc[-1, :].sort_values(ascending=False)
         joint.append(df_1)
-        all_colors.append([colors[idx]]*len(df_1.index))
+        all_colors.append([colors[idx]] * len(df_1.index))
     joint = pd.concat(joint)
 
     joint_predicted = []
@@ -93,41 +107,46 @@ def run_european_screener(prices: pd.DataFrame,
         joint_predicted.append(df_next_1)
     joint_predicted = pd.concat(joint_predicted)
 
-    joint = joint.apply(lambda x: 2.0*norm.cdf(x)-1.0)
-    joint_predicted = joint_predicted.apply(lambda x: 2.0*norm.cdf(x)-1.0)
+    joint = joint.apply(lambda x: 2.0 * norm.cdf(x) - 1.0)
+    joint_predicted = joint_predicted.apply(lambda x: 2.0 * norm.cdf(x) - 1.0)
     all_colors = qis.to_flat_list(all_colors)
 
     with sns.axes_style("darkgrid"):
         fig, ax = plt.subplots(1, 1, figsize=(8, 16), tight_layout=True)
 
-        qis.plot_vbars(df=joint,
-                       colors=all_colors,
-                       totals=joint_predicted.loc[joint.index].to_list(),
-                       fontsize=8,
-                       axvline_color=None,
-                       var_format='{:.2f}',
-                       x_limits=(-1.0, 1.0),
-                       bbox_to_anchor=None,
-                       add_bar_values=False,
-                       add_total_bar=True,
-                       total_bar_linestyle='dotted',
-                       total_bar_linewidth=3,
-                       is_category_names_colors=False,
-                       xlabel='Signal',
-                       ax=ax)
-        set_legend(ax=ax,
-                       labels=list(dfs.keys()),
-                       colors=colors,
-                       legend_loc='upper left',
-                       fontsize=10,
-                       reverse_columns=False,
-                       framealpha=0.9,
-                       bbox_to_anchor=None)
+        qis.plot_vbars(
+            df=joint,
+            colors=all_colors,
+            totals=joint_predicted.loc[joint.index].to_list(),
+            fontsize=8,
+            axvline_color=None,
+            var_format='{:.2f}',
+            x_limits=(-1.0, 1.0),
+            bbox_to_anchor=None,
+            add_bar_values=False,
+            add_total_bar=True,
+            total_bar_linestyle='dotted',
+            total_bar_linewidth=3,
+            is_category_names_colors=False,
+            xlabel='Signal',
+            ax=ax,
+        )
+        set_legend(
+            ax=ax,
+            labels=list(dfs.keys()),
+            colors=colors,
+            legend_loc='upper left',
+            fontsize=10,
+            reverse_columns=False,
+            framealpha=0.9,
+            bbox_to_anchor=None,
+        )
         # add american
         am_position_t = am_position.iloc[-1, :].loc[joint.index].to_list()
         for idx, total in enumerate(am_position_t):
-            # ax.vlines(x=total, ymin=idx-0.25, ymax=idx+0.25, marker='o', linestyle='None', color='red', linewidth=3, )
-            ax.scatter(x=0.995*total, y=idx, marker='o', color='red', s=3, zorder=10)
+            # Alternative presentation: draw a short red vertical marker from
+            # y=idx-0.25 to y=idx+0.25 at x=total.
+            ax.scatter(x=0.995 * total, y=idx, marker='o', color='red', s=3, zorder=10)
         ax.margins(x=0.01)
 
         for idx, t in enumerate(ax.yaxis.get_ticklabels()):
@@ -135,11 +154,11 @@ def run_european_screener(prices: pd.DataFrame,
     return fig
 
 
-
 class LocalTests(Enum):
     """
     runnable example cases
     """
+
     TF_UNIVERSE = 1
     SMALL_UNIVERSE = 2
 
@@ -155,42 +174,53 @@ def run_local_test(local_test: LocalTests):
     pd.set_option('display.max_columns', 500)
     pd.set_option('display.width', 1000)
 
-    local_path = os.environ.get("TF_FIGURE_PATH", qis.local_path.get_output_path())  # set TF_FIGURE_PATH to the paper figures folder
+    local_path = os.environ.get(
+        "TF_FIGURE_PATH", qis.local_path.get_output_path()
+    )  # set TF_FIGURE_PATH to the paper figures folder
 
     if local_test == LocalTests.TF_UNIVERSE:
         time_period = qis.TimePeriod(start='31Dec1998', end=None)
         from trendfollowing.universe import load_data
-        prices, volume_costs, benchmark_prices, group_data, group_order = load_data(time_period=time_period)
+
+        prices, volume_costs, benchmark_prices, group_data, group_order = load_data(
+            time_period=time_period
+        )
 
         prices = prices.rename(group_data['names'].to_dict(), axis=1)
         group_data = group_data.rename(group_data['names'].to_dict(), axis=0)['group_data']
         fig = run_european_screener(prices=prices, group_data=group_data, group_order=group_order)
-        qis.save_fig(fig, file_name='tf_signal', local_path=qis.get_output_path())
+        qis.save_fig(fig, file_name='tf_signal', local_path=local_path)
 
     elif local_test == LocalTests.SMALL_UNIVERSE:
         from bbg_fetch import fetch_field_timeseries_per_tickers
+
         time_period = qis.TimePeriod(start='31Dec1998', end=None)
 
-        tickers = {'SPX Index': 'S&P500',
-                   'DAX Index': 'DAX',
-                   'TY1 Comdty': 'UST',
-                   'RX1 Comdty': 'Bunds',
-                   'LGCPTRUH Index': 'IG',
-                   'LG30TRUH Index': 'HY',
-                   'EUR BGN Curncy': 'EUR',
-                   'JPY BGN Curncy': 'JPY'}
-        group_data = pd.Series(['EQ', 'EQ', 'FI', 'FI', 'Credit', 'Credit', 'FX', 'FX'], index=list(tickers.values()))
-        prices = fetch_field_timeseries_per_tickers(tickers=tickers, freq='B', field='PX_LAST').ffill()
+        tickers = {
+            'SPX Index': 'S&P500',
+            'DAX Index': 'DAX',
+            'TY1 Comdty': 'UST',
+            'RX1 Comdty': 'Bunds',
+            'LGCPTRUH Index': 'IG',
+            'LG30TRUH Index': 'HY',
+            'EUR BGN Curncy': 'EUR',
+            'JPY BGN Curncy': 'JPY',
+        }
+        group_data = pd.Series(
+            ['EQ', 'EQ', 'FI', 'FI', 'Credit', 'Credit', 'FX', 'FX'], index=list(tickers.values())
+        )
+        prices = fetch_field_timeseries_per_tickers(
+            tickers=tickers, freq='B', field='PX_LAST'
+        ).ffill()
         prices = time_period.locate(prices)
 
-        fig = run_european_screener(prices=prices, group_data=group_data, group_order=['EQ', 'FI', 'Credit', 'FX'])
-        qis.save_fig(fig, file_name='tf_signal', local_path=qis.get_output_path())
-
+        fig = run_european_screener(
+            prices=prices, group_data=group_data, group_order=['EQ', 'FI', 'Credit', 'FX']
+        )
+        qis.save_fig(fig, file_name='tf_signal', local_path=local_path)
 
     plt.show()
 
 
 if __name__ == '__main__':
-
     run_local_test(local_test=LocalTests.TF_UNIVERSE)
-

--- a/src/trendfollowing/analysis/trade_ar_process.py
+++ b/src/trendfollowing/analysis/trade_ar_process.py
@@ -4,6 +4,7 @@ forecast with linear or sign sizing, with pacf diagnostics of the simulated path
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 import pandas as pd
@@ -21,10 +22,7 @@ from trendfollowing.processes.path_engine import set_seed, simulate_ar_p_paths
 
 
 @njit
-def trade_ar1(xt: np.ndarray,
-              phi: np.ndarray,
-              is_ar_sizing: bool = True
-              ) -> np.ndarray:
+def trade_ar1(xt: np.ndarray, phi: np.ndarray, is_ar_sizing: bool = True) -> np.ndarray:
     """
     cumulative pnl of trading the one-step ar(p) forecast on each path, with the
     size equal to the forecast (linear sizing) or its sign
@@ -35,12 +33,12 @@ def trade_ar1(xt: np.ndarray,
     pnl = np.zeros((m_times, n_path))
 
     for t in np.arange(p, m_times):
-        forecast_1 = phi_ @ np.ascontiguousarray(xt[t-p: t, :])
+        forecast_1 = phi_ @ np.ascontiguousarray(xt[t - p : t, :])
         if is_ar_sizing:
             size = forecast_1
         else:
             size = np.sign(forecast_1)
-        pnl[t, :] = pnl[t-1, :] + size * xt[t, :]
+        pnl[t, :] = pnl[t - 1, :] + size * xt[t, :]
 
     return pnl
 
@@ -59,6 +57,7 @@ class LocalTests(Enum):
     """
     runnable example cases
     """
+
     AR1 = 1
     TRADE_AR1 = 2
     OU_SECONDS_PATHS = 3
@@ -75,35 +74,31 @@ def run_local_test(local_test: LocalTests):
     set_seed(1)
 
     if local_test == LocalTests.AR1:
-        #phi = np.array([-0.5])
-        #x0 = np.array([1.0])
+        # phi = np.array([-0.5])
+        # x0 = np.array([1.0])
         phi = np.array([-0.6, 0.3])
         x0 = np.array([0.0, 0.0])
 
         n_path = 100
         n_path_cut = 20
-        paths = simulate_ar_p_paths(phi=phi,
-                                    x0=x0,
-                                    n_path=n_path,
-                                    m_times=1000,
-                                    c=0.0,
-                                    noise_std=1.0)
+        paths = simulate_ar_p_paths(
+            phi=phi, x0=x0, n_path=n_path, m_times=1000, c=0.0, noise_std=1.0
+        )
         acfs, m_acf, std_acf = qis.estimate_acf_from_paths(paths=paths, is_pacf=True)
-        paths = pd.DataFrame(paths, columns=[f"path{p+1}" for p in range(n_path)])
+        paths = pd.DataFrame(paths, columns=[f"path{p + 1}" for p in range(n_path)])
 
         with sns.axes_style("darkgrid"):
             fig, axs = plt.subplots(2, 2, figsize=(18, 10), tight_layout=True)
         qis.plot_line(df=paths.iloc[:, :n_path_cut], ax=axs[0][0])
         qis.plot_histogram(df=paths.iloc[:, :n_path_cut], ax=axs[0][1])
-        plot_pacf(paths.iloc[:, 0], lags=10, title=f"path0", ax=axs[1][0])
+        plot_pacf(paths.iloc[:, 0], lags=10, title="path0", ax=axs[1][0])
         # peb.errorbar(df=m_acf, y_std_errors=std_acf, var_format='{:.2%}', ax=axs[1][1])
         qis.df_boxplot_by_index(df=acfs, ax=axs[1][1])
         print(pacf(paths.iloc[:, 0], nlags=10))
 
     elif local_test == LocalTests.TRADE_AR1:
-
-        #phi1 = -0.4
-        #phi = np.array([-0.6, 0.3])
+        # phi1 = -0.4
+        # phi = np.array([-0.6, 0.3])
 
         # phi = np.array([0.5])
         phi = np.array([-0.4, 0.1, 0.1])
@@ -113,11 +108,7 @@ def run_local_test(local_test: LocalTests):
 
         n_path = 1000
         m_times = 1000
-        xt = simulate_ar_p_paths(phi=phi,
-                                 n_path=n_path,
-                                 m_times=m_times,
-                                 mean=0.0,
-                                 noise_std=1.0)
+        xt = simulate_ar_p_paths(phi=phi, n_path=n_path, m_times=m_times, mean=0.0, noise_std=1.0)
 
         name1 = 'Forecast Size'
         name2 = 'Sign Size'
@@ -140,9 +131,13 @@ def run_local_test(local_test: LocalTests):
         kwargs = dict(legend_loc=None)
 
         acfs, m_acf, std_acf = qis.estimate_acf_from_paths(paths=xt, is_pacf=True)
-        qis.df_boxplot_by_index(df=acfs, title='Partial AFC', ylabel=r'$\rho$', y_limits=(-1, 1), ax=axs[0][0])
+        qis.df_boxplot_by_index(
+            df=acfs, title='Partial AFC', ylabel=r'$\rho$', y_limits=(-1, 1), ax=axs[0][0]
+        )
         acfs, m_acf, std_acf = qis.estimate_acf_from_paths(paths=xt, is_pacf=False)
-        qis.df_boxplot_by_index(df=acfs, title='AFC', ylabel=r'$\rho$', y_limits=(-1, 1), ax=axs[1][0])
+        qis.df_boxplot_by_index(
+            df=acfs, title='AFC', ylabel=r'$\rho$', y_limits=(-1, 1), ax=axs[1][0]
+        )
 
         qis.plot_line(df=pnls[name1], title=f"P&L path: {name1}", ax=axs[0][1], **kwargs)
         qis.plot_line(df=pnls[name2], title=f"P&L path: {name2}", ax=axs[1][1], **kwargs)
@@ -156,7 +151,6 @@ def run_local_test(local_test: LocalTests):
 
 
 if __name__ == '__main__':
-
     local_test = LocalTests.TRADE_AR1
 
     run_local_test(local_test=local_test)

--- a/src/trendfollowing/analytics/autocorrelation.py
+++ b/src/trendfollowing/analytics/autocorrelation.py
@@ -3,16 +3,18 @@ population autocorrelation functions of white noise, ar-1, and arfima processes
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 from scipy.signal import lfilter
 from scipy.special import gamma as sp_gamma, hyp2f1
 
 
-def population_acf(n_lags: int = 250,
-                   phi: float = 0.0,  # ar-1 coefficient, |phi| < 1
-                   d: float = 0.0,  # arfima fractional order, |d| < 0.5
-                   ) -> np.ndarray:
+def population_acf(
+    n_lags: int = 250,
+    phi: float = 0.0,  # ar-1 coefficient, |phi| < 1
+    d: float = 0.0,  # arfima fractional order, |d| < 0.5
+) -> np.ndarray:
     """
     population autocorrelation rho(m), m = 0..n_lags, with rho(0) = 1
     white noise: rho(m) = delta_{m=0}; ar-1: rho(m) = phi^m
@@ -37,7 +39,8 @@ def population_acf(n_lags: int = 250,
             rho[m] = rho[m - 1] * (m - 1.0 + d) / (m - d)
     else:
         # sowell (1992) autocovariance of arfima(1,d,0) with unit innovation variance
-        # the gamma-function ratio is computed by the stable recursion ratio0(h) = ratio0(h-1)*(h-1+d)/(h-d)
+        # The gamma-function ratio is computed by the stable recursion
+        # ratio0(h) = ratio0(h-1)*(h-1+d)/(h-d).
         c0 = sp_gamma(1.0 - 2.0 * d) / np.square(sp_gamma(1.0 - d))
         ratio1 = 1.0 / ((1.0 - phi) * hyp2f1(1.0, 1.0 + d, 1.0 - d, phi))
         gammas = np.zeros(n_lags + 1)
@@ -45,14 +48,15 @@ def population_acf(n_lags: int = 250,
         for h in lags:
             if h > 0:
                 ratio0 = ratio0 * (h - 1.0 + d) / (h - d)
-            enumerator = hyp2f1(1.0, d + h, 1.0 - d + h, phi) + hyp2f1(1.0, d - h, 1.0 - d - h, phi) - 1.0
+            enumerator = (
+                hyp2f1(1.0, d + h, 1.0 - d + h, phi) + hyp2f1(1.0, d - h, 1.0 - d - h, phi) - 1.0
+            )
             gammas[h] = c0 * ratio1 * ratio0 * enumerator
         rho = gammas / gammas[0]
     return rho
 
-def compute_psi_nu(rho: np.ndarray,
-                   nu: float
-                   ) -> float:
+
+def compute_psi_nu(rho: np.ndarray, nu: float) -> float:
     """
     psi_nu = sum_{m>=1} nu^m rho(m) = phi_nu - 1, truncated at len(rho)-1 lags
     """
@@ -63,13 +67,16 @@ def compute_psi_nu(rho: np.ndarray,
     nu_powers = np.power(nu, np.arange(1, len(rho)))
     return float(np.sum(nu_powers * rho[1:]))
 
-def power_autocorr(delta: float,  # arfima fractional order, |delta| < 0.5; 0 selects the ar-1 branch
-                   phi: float = 0.0,  # ar-1 coefficient, |phi| < 1
-                   n: int = 100  # number of lags
-                   ) -> np.ndarray:
+
+def power_autocorr(
+    delta: float,  # arfima fractional order, |delta| < 0.5; 0 selects the ar-1 branch
+    phi: float = 0.0,  # ar-1 coefficient, |phi| < 1
+    n: int = 100,  # number of lags
+) -> np.ndarray:
     """
     ar-1 branch (delta=0) returns autocorrelation powers phi^h with lag 0 equal to one
-    arfima branches return the autocovariance gamma(h) with lag 0 set to zero, the convention used by expected_pnl_arfima
+    arfima branches return the autocovariance gamma(h) with lag 0 set to zero,
+    the convention used by expected_pnl_arfima
     """
     if not np.abs(phi) < 1.0:
         raise ValueError(f"phi must satisfy |phi| < 1, got {phi!r}")
@@ -81,35 +88,42 @@ def power_autocorr(delta: float,  # arfima fractional order, |delta| < 0.5; 0 se
         acf = np.cumprod(phi * np.ones(n)) / phi  # = 1, phi, phi^2,...
     else:
         acf = np.zeros(n)
-        sigma0 = sp_gamma(1.0 - 2.0 * delta) / (sp_gamma(1.0 - delta)**2)
-        ratio = sp_gamma(1. - delta) / sp_gamma(delta)
+        sigma0 = sp_gamma(1.0 - 2.0 * delta) / (sp_gamma(1.0 - delta) ** 2)
+        ratio = sp_gamma(1.0 - delta) / sp_gamma(delta)
         if np.isclose(phi, 0.0):
             for h in np.arange(n):
-                acf[h] = ratio * sp_gamma(h+delta) / sp_gamma(1.0+h-delta)
+                acf[h] = ratio * sp_gamma(h + delta) / sp_gamma(1.0 + h - delta)
             acf[0] = 0.0
         else:
             ratio1 = 1.0 / ((1.0 - phi) * hyp2f1(1.0, 1.0 + delta, 1.0 - delta, phi))
 
             def arfima_1d(k):
-                ratio0 = ratio * sp_gamma(k+delta) / sp_gamma(1.0+k-delta)
-                enumerator = (hyp2f1(1, k+delta, 1.0-delta+k, phi) + hyp2f1(1, delta-k, 1.0-delta-k, phi) -1.0)
-                return ratio0 *ratio1 * enumerator
+                ratio0 = ratio * sp_gamma(k + delta) / sp_gamma(1.0 + k - delta)
+                enumerator = (
+                    hyp2f1(1, k + delta, 1.0 - delta + k, phi)
+                    + hyp2f1(1, delta - k, 1.0 - delta - k, phi)
+                    - 1.0
+                )
+                return ratio0 * ratio1 * enumerator
 
             for h in np.arange(n):
                 acf[h] = arfima_1d(k=h)
             acf[0] = 0.0
-        acf = sigma0*acf
+        acf = sigma0 * acf
     return acf
 
 
-def ma_weights(phi: float = 0.0,  # ar-1 coefficient, |phi| < 1
-               d: float = 0.0,  # arfima fractional order, |d| < 0.5
-               n_lags: int = 8000,  # truncation of the ma expansion
-               ) -> np.ndarray:
+def ma_weights(
+    phi: float = 0.0,  # ar-1 coefficient, |phi| < 1
+    d: float = 0.0,  # arfima fractional order, |d| < 0.5
+    n_lags: int = 8000,  # truncation of the ma expansion
+) -> np.ndarray:
     """
     normalised moving-average weights of the arfima(1,d,0) process, sum psi^2 = 1
-    fractional weights pi_j = Gamma(j+d)/(Gamma(j+1)Gamma(d)) by the recursion pi_j = pi_{j-1}*(j-1+d)/j with pi_0 = 1
-    the ar part applies 1/(1 - phi*L), so psi = pi convolved with phi^k, normalised to a unit sum of squares
+    fractional weights pi_j = Gamma(j+d)/(Gamma(j+1)Gamma(d)) by the recursion
+    pi_j = pi_{j-1}*(j-1+d)/j with pi_0 = 1
+    the ar part applies 1/(1 - phi*L), so psi = pi convolved with phi^k,
+    normalised to a unit sum of squares
     """
     if not np.abs(phi) < 1.0:
         raise ValueError(f"phi must satisfy |phi| < 1, got {phi!r}")

--- a/src/trendfollowing/analytics/expected_return.py
+++ b/src/trendfollowing/analytics/expected_return.py
@@ -3,25 +3,30 @@ expected annual return and turnover of the european tf system per process (paper
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 from typing import Optional
+
 # project
 from trendfollowing.analytics.filters import span_to_nu, compute_ewm_long_short_weights
 from trendfollowing.analytics.autocorrelation import power_autocorr
 
 
-def expected_pnl_white_noise(long_span: float,
-                             short_span: Optional[float] = None,
-                             mean: float = 0.0,
-                             vol_target: float = 0.15,
-                             annualization_factor: float = 260.0
-                             ) -> float:
+def expected_pnl_white_noise(
+    long_span: float,
+    short_span: Optional[float] = None,
+    mean: float = 0.0,
+    vol_target: float = 0.15,
+    annualization_factor: float = 260.0,
+) -> float:
     """
     expected annual return of the european system under white noise (drift channel only)
     F = sigma_target/sqrt(a) * (w_l - w_s) * mu^2: the autocorrelation channel is zero
     """
-    weight_long, weight_short = compute_ewm_long_short_weights(long_span=long_span, short_span=short_span)
+    weight_long, weight_short = compute_ewm_long_short_weights(
+        long_span=long_span, short_span=short_span
+    )
     if short_span is not None:
         pnl = (weight_long - weight_short) * mean**2
     else:
@@ -29,13 +34,15 @@ def expected_pnl_white_noise(long_span: float,
     pnl = vol_target * pnl / np.sqrt(annualization_factor)
     return pnl
 
-def expected_pnl_ar1(phi: float,
-                     long_span: float,
-                     short_span: Optional[float] = None,
-                     vol_target: float = 0.15,
-                     mean: float = 0.0,
-                     annualization_factor: float = 260.0
-                     ) -> float:
+
+def expected_pnl_ar1(
+    phi: float,
+    long_span: float,
+    short_span: Optional[float] = None,
+    vol_target: float = 0.15,
+    mean: float = 0.0,
+    annualization_factor: float = 260.0,
+) -> float:
     """
     expected annual return of the european system under ar-1 (paper corollary)
     per leg, the autocorrelation channel sums the geometric series:
@@ -43,64 +50,76 @@ def expected_pnl_ar1(phi: float,
     which reduces to sqrt(a)*sigma_target * w * phi*(1-nu)/(1-nu*phi) per unit loading;
     the drift channel adds the white-noise term when mean > 0
     """
-    weight_long, weight_short = compute_ewm_long_short_weights(long_span=long_span, short_span=short_span)
+    weight_long, weight_short = compute_ewm_long_short_weights(
+        long_span=long_span, short_span=short_span
+    )
     long_nu = span_to_nu(span=long_span)
     if short_span is not None:
         short_nu = span_to_nu(span=short_span)
-        pnl_long = phi*(1.0-long_nu) / (1.0-long_nu*phi)
-        pnl_short = phi*(1.0-short_nu) / (1.0-short_nu*phi)
+        pnl_long = phi * (1.0 - long_nu) / (1.0 - long_nu * phi)
+        pnl_short = phi * (1.0 - short_nu) / (1.0 - short_nu * phi)
         pnl = weight_long * pnl_long - weight_short * pnl_short
     else:
-        pnl = weight_long * phi*(1.0-long_nu) / (1.0-long_nu*phi)
-    pnl = np.sqrt(annualization_factor)*vol_target * pnl
+        pnl = weight_long * phi * (1.0 - long_nu) / (1.0 - long_nu * phi)
+    pnl = np.sqrt(annualization_factor) * vol_target * pnl
     if mean > 0.0:
-        mean_pnl = expected_pnl_white_noise(long_span=long_span,
-                                            short_span=short_span,
-                                            mean=mean,
-                                            vol_target=vol_target,
-                                            annualization_factor=annualization_factor)
+        mean_pnl = expected_pnl_white_noise(
+            long_span=long_span,
+            short_span=short_span,
+            mean=mean,
+            vol_target=vol_target,
+            annualization_factor=annualization_factor,
+        )
         pnl += mean_pnl
     return pnl
 
-def expected_pnl_ma1(phi: float,
-                     long_span: float,
-                     short_span: Optional[float] = None,
-                     vol_target: float = 0.15,
-                     mean: float = 0.0,
-                     annualization_factor: float = 260.0
-                     ) -> float:
+
+def expected_pnl_ma1(
+    phi: float,
+    long_span: float,
+    short_span: Optional[float] = None,
+    vol_target: float = 0.15,
+    mean: float = 0.0,
+    annualization_factor: float = 260.0,
+) -> float:
     """
     expected annual return of the european system under ma-1
     only the first autocorrelation is non-zero, rho(1) = phi/(1+phi^2), so the
     autocorrelation channel per leg is w * nu*rho(1) * (1-nu)/nu = w * phi*(1-nu)/(1+phi^2)
     """
-    weight_long, weight_short = compute_ewm_long_short_weights(long_span=long_span, short_span=short_span)
+    weight_long, weight_short = compute_ewm_long_short_weights(
+        long_span=long_span, short_span=short_span
+    )
     long_nu = span_to_nu(span=long_span)
     if short_span is not None:
         short_nu = span_to_nu(span=short_span)
-        pnl_long = phi*(1.0-long_nu) / (1.0+phi*phi)
-        pnl_short = phi*(1.0-short_nu) / (1.0+phi*phi)
+        pnl_long = phi * (1.0 - long_nu) / (1.0 + phi * phi)
+        pnl_short = phi * (1.0 - short_nu) / (1.0 + phi * phi)
         pnl = weight_long * pnl_long - weight_short * pnl_short
     else:
-        pnl = weight_long * phi*(1.0-long_nu) / (1.0+phi*phi)
-    pnl = np.sqrt(annualization_factor)*vol_target * pnl
+        pnl = weight_long * phi * (1.0 - long_nu) / (1.0 + phi * phi)
+    pnl = np.sqrt(annualization_factor) * vol_target * pnl
     if mean > 0.0:
-        mean_pnl = expected_pnl_white_noise(long_span=long_span,
-                                            short_span=short_span,
-                                            mean=mean,
-                                            vol_target=vol_target,
-                                            annualization_factor=annualization_factor)
+        mean_pnl = expected_pnl_white_noise(
+            long_span=long_span,
+            short_span=short_span,
+            mean=mean,
+            vol_target=vol_target,
+            annualization_factor=annualization_factor,
+        )
         pnl += mean_pnl
     return pnl
 
-def expected_pnl_arfima(delta: float,
-                        long_span: float,
-                        short_span: Optional[float] = None,
-                        phi: float = 0.0,
-                        vol_target: float = 0.15,
-                        mean: float = 0.0,
-                        annualization_factor: float = 260.0
-                        ) -> float:
+
+def expected_pnl_arfima(
+    delta: float,
+    long_span: float,
+    short_span: Optional[float] = None,
+    phi: float = 0.0,
+    vol_target: float = 0.15,
+    mean: float = 0.0,
+    annualization_factor: float = 260.0,
+) -> float:
     """
     expected annual return of the european system under arfima(1,delta,0)
     the autocorrelation channel evaluates h * sum_m nu^m gamma(m) on the sowell
@@ -114,37 +133,43 @@ def expected_pnl_arfima(delta: float,
         pnl = 0.0
         nu_m = 1.0
         for pk_ in pk:
-            pnl += nu_m*pk_
+            pnl += nu_m * pk_
             nu_m *= nu
-        norm = (1.0-nu) / nu
-        return norm*pnl
+        norm = (1.0 - nu) / nu
+        return norm * pnl
 
-    weight_long, weight_short = compute_ewm_long_short_weights(long_span=long_span, short_span=short_span)
+    weight_long, weight_short = compute_ewm_long_short_weights(
+        long_span=long_span, short_span=short_span
+    )
 
     if short_span is not None:
         pnl_long = compute_nu_filter(span=long_span)
         pnl_short = compute_nu_filter(span=short_span)
-        pnl = weight_long*pnl_long - weight_short*pnl_short
+        pnl = weight_long * pnl_long - weight_short * pnl_short
     else:
         pnl = weight_long * compute_nu_filter(span=long_span)
 
-    pnl = (np.sqrt(annualization_factor)*vol_target)*pnl
+    pnl = (np.sqrt(annualization_factor) * vol_target) * pnl
 
     if mean > 0.0:
-        mean_pnl = expected_pnl_white_noise(long_span=long_span,
-                                            short_span=short_span,
-                                            mean=mean,
-                                            vol_target=vol_target,
-                                            annualization_factor=annualization_factor)
+        mean_pnl = expected_pnl_white_noise(
+            long_span=long_span,
+            short_span=short_span,
+            mean=mean,
+            vol_target=vol_target,
+            annualization_factor=annualization_factor,
+        )
         pnl += mean_pnl
 
     return pnl
 
-def expected_turnover(long_span: float,
-                      short_span: Optional[float] = None,
-                      annualization_factor: float = 260.0,
-                      vol_target: float = 0.15
-                      ) -> float:
+
+def expected_turnover(
+    long_span: float,
+    short_span: Optional[float] = None,
+    annualization_factor: float = 260.0,
+    vol_target: float = 0.15,
+) -> float:
     """
     expected annualised turnover of the european system under serial independence
     U = 2*a*sigma_target*sqrt(zeta/pi) with zeta the variance of the one-step signal
@@ -152,18 +177,26 @@ def expected_turnover(long_span: float,
     difference variance for the long-short filter (paper eq tur_ls)
     """
     nu_long = span_to_nu(span=long_span)
-    coeff = 2.0*annualization_factor*vol_target*np.sqrt(1.0/np.pi)
+    coeff = 2.0 * annualization_factor * vol_target * np.sqrt(1.0 / np.pi)
     if short_span is None:
-        turnover = coeff*np.sqrt(1.0 - nu_long)
+        turnover = coeff * np.sqrt(1.0 - nu_long)
     else:
         nu_short = span_to_nu(span=short_span)
         # variance-preserving normalization q = D^{-1/2} of the raw-filter difference
-        d_norm = 1.0/(1.0-nu_long**2) + 1.0/(1.0-nu_short**2) - 2.0/(1.0-nu_long*nu_short)
-        q = d_norm ** -0.5
-        # signal increment variance: the z_t terms cancel, leaving q^2 * var of the raw-filter difference
-        zeta = 0.5 * q**2 * ((1.0-nu_long)/(1.0+nu_long) + (1.0-nu_short)/(1.0+nu_short)
-                             - 2.0*(1.0-nu_long)*(1.0-nu_short)/(1.0-nu_long*nu_short))
+        d_norm = (
+            1.0 / (1.0 - nu_long**2) + 1.0 / (1.0 - nu_short**2) - 2.0 / (1.0 - nu_long * nu_short)
+        )
+        q = d_norm**-0.5
+        # The z_t terms cancel, leaving q^2 times the raw-filter difference variance.
+        zeta = (
+            0.5
+            * q**2
+            * (
+                (1.0 - nu_long) / (1.0 + nu_long)
+                + (1.0 - nu_short) / (1.0 + nu_short)
+                - 2.0 * (1.0 - nu_long) * (1.0 - nu_short) / (1.0 - nu_long * nu_short)
+            )
+        )
         turnover = coeff * np.sqrt(zeta)
-
 
     return turnover

--- a/src/trendfollowing/analytics/filters.py
+++ b/src/trendfollowing/analytics/filters.py
@@ -3,6 +3,7 @@ ewma filter parameters: span-to-nu mapping and variance-preserving long-short lo
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 from typing import Optional, Tuple
@@ -16,9 +17,11 @@ def span_to_nu(span: float) -> float:
         raise ValueError(f"span must be positive, got {span!r}")
     return 1.0 - 2.0 / (span + 1.0)
 
-def compute_ewm_long_short_weights(long_span: float = 63,
-                                   short_span: Optional[float] = None  # None for the single-filter system
-                                   ) -> Tuple[float, float]:
+
+def compute_ewm_long_short_weights(
+    long_span: float = 63,
+    short_span: Optional[float] = None,  # None for the single-filter system
+) -> Tuple[float, float]:
     """
     variance-preserving loadings of the (long-short) ewma filter
     single filter: w_l = sqrt((1+nu)/(1-nu)), w_s = 0; long-short: the raw-filter
@@ -30,7 +33,11 @@ def compute_ewm_long_short_weights(long_span: float = 63,
         short_lambda = span_to_nu(span=short_span)
         short_lambda2 = np.square(short_lambda)
         long_lambda2 = np.square(long_lambda)
-        covar = np.sqrt(1.0 / (1.0 - long_lambda2) + 1.0 / (1.0 - short_lambda2) - 2.0 / (1.0 - long_lambda * short_lambda))
+        covar = np.sqrt(
+            1.0 / (1.0 - long_lambda2)
+            + 1.0 / (1.0 - short_lambda2)
+            - 2.0 / (1.0 - long_lambda * short_lambda)
+        )
         weight_long = 1.0 / (np.sqrt(1.0 - long_lambda2) * covar)
         weight_short = 1.0 / (np.sqrt(1.0 - short_lambda2) * covar)
         load_long = np.sqrt((1.0 + long_lambda) / (1.0 - long_lambda))

--- a/src/trendfollowing/analytics/sharpe.py
+++ b/src/trendfollowing/analytics/sharpe.py
@@ -1,20 +1,25 @@
 """
 analytical sharpe ratio of the european tf system
-daily strategy return: f_t = (l*sigma_target/sqrt(af)) * S_{t-1} * z_t with signal S_{t-1} = filter of {z_{t-1}, z_{t-2}, ...}
-we compute E[f_t] and Var[f_t] under jointly gaussian z with population mean mu, variance theta, acf rho(m),
-using the isserlis theorem for Var[X*Y]: Var[XY] = sx^2*sy^2 + sxy^2 + mx^2*sy^2 + my^2*sx^2 + 2*mx*my*sxy
+daily strategy return: f_t = (l*sigma_target/sqrt(af)) * S_{t-1} * z_t with
+signal S_{t-1} = filter of {z_{t-1}, z_{t-2}, ...}
+we compute E[f_t] and Var[f_t] under jointly gaussian z with population mean mu,
+variance theta, acf rho(m), using the isserlis theorem for Var[X*Y]:
+Var[XY] = sx^2*sy^2 + sxy^2 + mx^2*sy^2 + my^2*sx^2 + 2*mx*my*sxy
 annualised sharpe: sr = sqrt(af) * E[f_t] / sqrt(Var[f_t])
 key results: sr is independent of sigma_target and of the filter loading l
 notation follows the paper: nu = 1 - 2/(span+1), psi_nu = sum_{m>=1} nu^m rho(m) = phi_nu - 1
-kurtosis extension: Var[f] gains kappa*K_sig with K_sig = sum_{s>=1} psi_s^2 b_{s-1}^2 (paper eq sr_k), gaussian is kappa=0
+kurtosis extension: Var[f] gains kappa*K_sig with
+K_sig = sum_{s>=1} psi_s^2 b_{s-1}^2 (paper eq sr_k), gaussian is kappa=0
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 import pandas as pd
 from scipy.signal import lfilter
 from typing import Optional, Tuple, NamedTuple, Union
+
 # project
 from trendfollowing.analytics.filters import span_to_nu, compute_ewm_long_short_weights
 from trendfollowing.analytics.autocorrelation import population_acf, compute_psi_nu
@@ -22,20 +27,27 @@ from trendfollowing.analytics.autocorrelation import population_acf, compute_psi
 
 class SignalMoments(NamedTuple):
     """
-    moments of the signal S_{t-1} relative to z: E[S] = mu*s_mean, Var[S] = theta*s_var, Cov(z_t, S_{t-1}) = theta*s_cov
+    moments of the signal S_{t-1} relative to z: E[S] = mu*s_mean,
+    Var[S] = theta*s_var, Cov(z_t, S_{t-1}) = theta*s_cov
     """
+
     s_mean: float
     s_var: float
     s_cov: float
 
-def compute_signal_moments(rho: np.ndarray,
-                           long_span: float = 250,
-                           short_span: Optional[float] = None,  # None for single ewma filter
-                           ) -> SignalMoments:
+
+def compute_signal_moments(
+    rho: np.ndarray,
+    long_span: float = 250,
+    short_span: Optional[float] = None,  # None for single ewma filter
+) -> SignalMoments:
     """
     moments of the variance-preserving (long-short) ewma signal under population acf rho
-    single filter with loading l: E[S] = l*mu, Var[S] = theta*l^2*(1-nu)(1+2*psi)/(1+nu), Cov = theta*l*(1-nu)*psi/nu
-    long-short: S = l1*L1 - l2*L2 with cross-term Cov(L1,L2) = theta*(1-nu1)(1-nu2)(1+psi1+psi2)/(1-nu1*nu2)
+    single filter with loading l: E[S] = l*mu,
+    Var[S] = theta*l^2*(1-nu)(1+2*psi)/(1+nu),
+    Cov = theta*l*(1-nu)*psi/nu
+    long-short: S = l1*L1 - l2*L2 with cross-term
+    Cov(L1,L2) = theta*(1-nu1)(1-nu2)(1+psi1+psi2)/(1-nu1*nu2)
     """
     l1, l2 = compute_ewm_long_short_weights(long_span=long_span, short_span=short_span)
     nu1 = span_to_nu(long_span)
@@ -57,14 +69,17 @@ def compute_signal_moments(rho: np.ndarray,
         s_cov = l1 * c1 - l2 * c2
     return SignalMoments(s_mean=s_mean, s_var=s_var, s_cov=s_cov)
 
-def compute_daily_moments(rho: np.ndarray,
-                          long_span: float = 250,
-                          short_span: Optional[float] = None,
-                          mean: float = 0.0,  # daily mean mu of vol-normalised returns z
-                          variance: float = 1.0,  # daily variance theta of z, close to one by construction
-                          ) -> Tuple[float, float]:
+
+def compute_daily_moments(
+    rho: np.ndarray,
+    long_span: float = 250,
+    short_span: Optional[float] = None,
+    mean: float = 0.0,  # daily mean mu of vol-normalised returns z
+    variance: float = 1.0,  # daily variance theta of z, close to one by construction
+) -> Tuple[float, float]:
     """
-    daily mean and variance of f_t / c with c = l*sigma_target/sqrt(af), via the isserlis product-variance formula
+    daily mean and variance of f_t / c with c = l*sigma_target/sqrt(af),
+    via the isserlis product-variance formula
     E[f/c] = theta*s_cov + mu^2*s_mean
     Var[f/c] = theta*(theta*(s_var + s_cov^2) + mu^2*(s_var + s_mean^2 + 2*s_mean*s_cov))
     """
@@ -72,46 +87,56 @@ def compute_daily_moments(rho: np.ndarray,
         raise ValueError(f"variance must be positive, got {variance!r}")
     sm = compute_signal_moments(rho=rho, long_span=long_span, short_span=short_span)
     mean_f = variance * sm.s_cov + np.square(mean) * sm.s_mean
-    var_f = variance * (variance * (sm.s_var + np.square(sm.s_cov))
-                        + np.square(mean) * (sm.s_var + np.square(sm.s_mean) + 2.0 * sm.s_mean * sm.s_cov))
+    var_f = variance * (
+        variance * (sm.s_var + np.square(sm.s_cov))
+        + np.square(mean) * (sm.s_var + np.square(sm.s_mean) + 2.0 * sm.s_mean * sm.s_cov)
+    )
     return mean_f, var_f
 
-def compute_annualised_sharpe(rho: np.ndarray,
-                              long_span: float = 250,
-                              short_span: Optional[float] = None,
-                              sr_underlying: float = 0.0,  # annualised sharpe of z: sr = sqrt(af)*mu/sqrt(theta)
-                              variance: float = 1.0,
-                              kappa: float = 0.0,  # excess kurtosis of the innovations, 0 for gaussian
-                              ma_weights: Optional[np.ndarray] = None,  # normalised ma weights psi, required when kappa != 0
-                              af: float = 260.0,  # annualisation factor
-                              ) -> float:
+
+def compute_annualised_sharpe(
+    rho: np.ndarray,
+    long_span: float = 250,
+    short_span: Optional[float] = None,
+    sr_underlying: float = 0.0,  # annualised sharpe of z: sr = sqrt(af)*mu/sqrt(theta)
+    variance: float = 1.0,
+    kappa: float = 0.0,  # excess kurtosis of the innovations, 0 for gaussian
+    ma_weights: Optional[np.ndarray] = None,  # normalised ma weights psi, required when kappa != 0
+    af: float = 260.0,  # annualisation factor
+) -> float:
     """
     annualised sharpe of the european tf system: sr = sqrt(af)*E[f]/sqrt(Var[f])
     the scaling c = l*sigma_target/sqrt(af) cancels, so sr is independent of sigma_target and l
-    for kappa != 0 the variance gains variance^2*kappa*K_sig with the loading of compute_kurtosis_loading
+    for kappa != 0 the variance gains variance^2*kappa*K_sig with the loading of
+    compute_kurtosis_loading
     """
     mean = sr_underlying * np.sqrt(variance) / np.sqrt(af)
-    mean_f, var_f = compute_daily_moments(rho=rho,
-                                          long_span=long_span,
-                                          short_span=short_span,
-                                          mean=mean,
-                                          variance=variance)
+    mean_f, var_f = compute_daily_moments(
+        rho=rho, long_span=long_span, short_span=short_span, mean=mean, variance=variance
+    )
     if kappa != 0.0:
         if ma_weights is None:
-            raise ValueError(f"ma_weights is required for the kurtosis term, got kappa={kappa!r} and ma_weights=None")
-        k_sig = compute_kurtosis_loading(ma_weights=ma_weights,
-                                         long_span=long_span,
-                                         short_span=short_span)
+            raise ValueError(
+                f"ma_weights is required for the kurtosis term, got kappa={kappa!r} "
+                "and ma_weights=None"
+            )
+        k_sig = compute_kurtosis_loading(
+            ma_weights=ma_weights, long_span=long_span, short_span=short_span
+        )
         var_f = var_f + np.square(variance) * kappa * k_sig
     return float(np.sqrt(af) * mean_f / np.sqrt(var_f))
 
-def compute_kurtosis_loading(ma_weights: np.ndarray,
-                             long_span: float = 250,
-                             short_span: Optional[float] = None,  # None for single ewma filter
-                             ) -> float:
+
+def compute_kurtosis_loading(
+    ma_weights: np.ndarray,
+    long_span: float = 250,
+    short_span: Optional[float] = None,  # None for single ewma filter
+) -> float:
     """
-    kurtosis loading of the signal: K_sig = sum_{s>=1} psi_s^2 b_{s-1}^2 (paper eq sr_k with the loadings included)
-    b_u = l1*c1_u - l2*c2_u with c_u = (1-nu) sum_{m<=u} nu^m psi_{u-m} the filter loading on innovation eps_{t-1-u}
+    kurtosis loading of the signal: K_sig = sum_{s>=1} psi_s^2 b_{s-1}^2
+    (paper eq sr_k with the loadings included)
+    b_u = l1*c1_u - l2*c2_u with c_u = (1-nu) sum_{m<=u} nu^m psi_{u-m},
+    the filter loading on innovation eps_{t-1-u}
     single filter: K_sig = l1^2 * K_nu with the unit-mass K_nu of eq sr_k
 
     Parameters
@@ -128,7 +153,10 @@ def compute_kurtosis_loading(ma_weights: np.ndarray,
     ValueError if ma_weights is not a one-dimensional unit-norm array
     """
     if ma_weights.ndim != 1 or ma_weights.shape[0] < 2:
-        raise ValueError(f"ma_weights must be a 1d array with at least two weights, got shape {ma_weights.shape!r}")
+        raise ValueError(
+            "ma_weights must be a 1d array with at least two weights, "
+            f"got shape {ma_weights.shape!r}"
+        )
     norm = float(np.sum(np.square(ma_weights)))
     if np.abs(norm - 1.0) > 1e-3:
         raise ValueError(f"ma_weights must satisfy sum psi^2 = 1, got {norm!r}")
@@ -141,116 +169,119 @@ def compute_kurtosis_loading(ma_weights: np.ndarray,
     return float(np.sum(np.square(ma_weights[1:]) * np.square(b[:-1])))
 
 
-def kurtosis_loading_ar1(phi: float,
-                         long_span: float = 250,
-                         ) -> float:
+def kurtosis_loading_ar1(
+    phi: float,
+    long_span: float = 250,
+) -> float:
     """
     closed form of the unit-mass kurtosis loading K_nu for the ar-1 process (paper eq sr_ar1_k)
-    K_nu = (1-nu)^2 (1-phi^2)^2/(phi-nu)^2 * (phi^4/(1-phi^4) - 2 nu phi^3/(1-nu phi^3) + nu^2 phi^2/(1-nu^2 phi^2))
+    K_nu = (1-nu)^2 (1-phi^2)^2/(phi-nu)^2 *
+    (phi^4/(1-phi^4) - 2 nu phi^3/(1-nu phi^3) +
+    nu^2 phi^2/(1-nu^2 phi^2))
     the signal-level loading of compute_kurtosis_loading equals l1^2 * K_nu for the single filter
     """
     if not np.abs(phi) < 1.0:
         raise ValueError(f"phi must satisfy |phi| < 1, got {phi!r}")
     nu = span_to_nu(long_span)
-    bracket = (phi ** 4 / (1.0 - phi ** 4)
-               - 2.0 * nu * phi ** 3 / (1.0 - nu * phi ** 3)
-               + nu ** 2 * phi ** 2 / (1.0 - nu ** 2 * phi ** 2))
-    return float((1.0 - nu) ** 2 * (1.0 - phi ** 2) ** 2 / (phi - nu) ** 2 * bracket)
+    bracket = (
+        phi**4 / (1.0 - phi**4)
+        - 2.0 * nu * phi**3 / (1.0 - nu * phi**3)
+        + nu**2 * phi**2 / (1.0 - nu**2 * phi**2)
+    )
+    return float((1.0 - nu) ** 2 * (1.0 - phi**2) ** 2 / (phi - nu) ** 2 * bracket)
 
 
-def sharpe_white_noise(long_span: float = 250,
-                       short_span: Optional[float] = None,
-                       sr_underlying: float = 0.5,
-                       af: float = 260.0
-                       ) -> float:
+def sharpe_white_noise(
+    long_span: float = 250,
+    short_span: Optional[float] = None,
+    sr_underlying: float = 0.5,
+    af: float = 260.0,
+) -> float:
     """
     exact tf sharpe under white noise with drift, from the generic formula with rho = delta_{m=0}
     single filter closed form: sr = sr_z^2*sqrt(span/af) / sqrt(1 + (sr_z^2/af)*(span+1))
     """
     rho = population_acf(n_lags=1)
-    return compute_annualised_sharpe(rho=rho,
-                                     long_span=long_span,
-                                     short_span=short_span,
-                                     sr_underlying=sr_underlying,
-                                     af=af)
+    return compute_annualised_sharpe(
+        rho=rho, long_span=long_span, short_span=short_span, sr_underlying=sr_underlying, af=af
+    )
 
-def sharpe_white_noise_approx(long_span: float = 250,
-                              sr_underlying: float = 0.5,
-                              af: float = 260.0
-                              ) -> float:
+
+def sharpe_white_noise_approx(
+    long_span: float = 250, sr_underlying: float = 0.5, af: float = 260.0
+) -> float:
     """
     leading-order tf sharpe under white noise: sr ~= sr_z^2 * sqrt(span/af)
     """
     return np.square(sr_underlying) * np.sqrt(long_span / af)
 
-def sharpe_ar1(phi: float,
-               long_span: float = 250,
-               short_span: Optional[float] = None,
-               sr_underlying: float = 0.0,
-               af: float = 260.0,
-               n_lags: int = 1000
-               ) -> float:
+
+def sharpe_ar1(
+    phi: float,
+    long_span: float = 250,
+    short_span: Optional[float] = None,
+    sr_underlying: float = 0.0,
+    af: float = 260.0,
+    n_lags: int = 1000,
+) -> float:
     """
     exact tf sharpe under ar-1 with coefficient phi, psi_nu = nu*phi/(1-nu*phi)
     """
     rho = population_acf(n_lags=n_lags, phi=phi)
-    return compute_annualised_sharpe(rho=rho,
-                                     long_span=long_span,
-                                     short_span=short_span,
-                                     sr_underlying=sr_underlying,
-                                     af=af)
+    return compute_annualised_sharpe(
+        rho=rho, long_span=long_span, short_span=short_span, sr_underlying=sr_underlying, af=af
+    )
 
-def sharpe_ar1_approx(phi: float,
-                      long_span: float = 250,
-                      af: float = 260.0
-                      ) -> float:
+
+def sharpe_ar1_approx(phi: float, long_span: float = 250, af: float = 260.0) -> float:
     """
-    leading-order tf sharpe under zero-drift ar-1: sr ~= 2*phi*sqrt(af)*sqrt(span)/(span+1) ~= 2*phi*sqrt(af/span)
+    leading-order tf sharpe under zero-drift ar-1:
+    sr ~= 2*phi*sqrt(af)*sqrt(span)/(span+1) ~= 2*phi*sqrt(af/span)
     """
     return 2.0 * phi * np.sqrt(af) * np.sqrt(long_span) / (long_span + 1.0)
 
-def sharpe_arfima(d: float,
-                  phi: float = 0.0,
-                  long_span: float = 250,
-                  short_span: Optional[float] = None,
-                  sr_underlying: float = 0.0,
-                  af: float = 260.0,
-                  n_lags: int = 2000
-                  ) -> float:
+
+def sharpe_arfima(
+    d: float,
+    phi: float = 0.0,
+    long_span: float = 250,
+    short_span: Optional[float] = None,
+    sr_underlying: float = 0.0,
+    af: float = 260.0,
+    n_lags: int = 2000,
+) -> float:
     """
     exact tf sharpe under arfima(1,d,0) using the sowell acf, truncated at n_lags
     """
     rho = population_acf(n_lags=n_lags, phi=phi, d=d)
-    return compute_annualised_sharpe(rho=rho,
-                                     long_span=long_span,
-                                     short_span=short_span,
-                                     sr_underlying=sr_underlying,
-                                     af=af)
+    return compute_annualised_sharpe(
+        rho=rho, long_span=long_span, short_span=short_span, sr_underlying=sr_underlying, af=af
+    )
 
-def expected_annual_return(rho: np.ndarray,
-                           long_span: float = 250,
-                           short_span: Optional[float] = None,
-                           sr_underlying: float = 0.0,
-                           vol_target: float = 0.15,
-                           af: float = 260.0
-                           ) -> float:
+
+def expected_annual_return(
+    rho: np.ndarray,
+    long_span: float = 250,
+    short_span: Optional[float] = None,
+    sr_underlying: float = 0.0,
+    vol_target: float = 0.15,
+    af: float = 260.0,
+) -> float:
     """
-    expected annual return af*c*E[f/c] with c = sigma_target/sqrt(af), loadings inside signal moments
+    expected annual return af*c*E[f/c] with c = sigma_target/sqrt(af),
+    loadings inside signal moments
     cross-checks the paper corollary: F_1y = c_1y*(phi_nu - 1) + (l*sigma_target/sqrt(af))*sr_z^2
     """
     mean = sr_underlying / np.sqrt(af)
-    mean_f, _ = compute_daily_moments(rho=rho,
-                                      long_span=long_span,
-                                      short_span=short_span,
-                                      mean=mean,
-                                      variance=1.0)
+    mean_f, _ = compute_daily_moments(
+        rho=rho, long_span=long_span, short_span=short_span, mean=mean, variance=1.0
+    )
     return float(af * (vol_target / np.sqrt(af)) * mean_f)
 
 
-def compute_realized_sharpe(returns: Union[np.ndarray, pd.Series, pd.DataFrame],
-                            af: float = 260.0,
-                            ddof: int = 1
-                            ) -> Union[float, pd.Series]:
+def compute_realized_sharpe(
+    returns: Union[np.ndarray, pd.Series, pd.DataFrame], af: float = 260.0, ddof: int = 1
+) -> Union[float, pd.Series]:
     """
     canonical realized Sharpe estimator SR = sqrt(af) * E[f_t] / sqrt(Var[f_t]) on periodic
     simple excess returns, shared by every estimation layer of the papers
@@ -265,4 +296,6 @@ def compute_realized_sharpe(returns: Union[np.ndarray, pd.Series, pd.DataFrame],
     elif isinstance(returns, (pd.Series, pd.DataFrame)):
         return np.sqrt(af) * returns.mean() / returns.std(ddof=ddof)
     else:
-        raise ValueError(f"returns must be np.ndarray, pd.Series, or pd.DataFrame, got {type(returns)!r}")
+        raise ValueError(
+            f"returns must be np.ndarray, pd.Series, or pd.DataFrame, got {type(returns)!r}"
+        )

--- a/src/trendfollowing/analytics/sharpe_test.py
+++ b/src/trendfollowing/analytics/sharpe_test.py
@@ -7,6 +7,7 @@ and the two-sided p-value uses the normal limit of the studentised difference
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 # packages
 import numpy as np
 import pandas as pd
@@ -18,6 +19,7 @@ class SharpeDiffTest(NamedTuple):
     """
     annualised sharpe ratios and their difference, with the hac t-statistic and p-value
     """
+
     sr1_an: float
     sr2_an: float
     diff_an: float
@@ -28,11 +30,12 @@ class SharpeDiffTest(NamedTuple):
     n_lags: int
 
 
-def sharpe_difference_test(returns1: pd.Series,
-                           returns2: pd.Series,
-                           n_lags: Optional[int] = None,  # bartlett lags, default floor(4*(T/100)^(2/9))
-                           af: float = 12.0  # annualisation factor of the return frequency
-                           ) -> SharpeDiffTest:
+def sharpe_difference_test(
+    returns1: pd.Series,
+    returns2: pd.Series,
+    n_lags: Optional[int] = None,  # bartlett lags, default floor(4*(T/100)^(2/9))
+    af: float = 12.0,  # annualisation factor of the return frequency
+) -> SharpeDiffTest:
     """
     test H0: sr(returns1) = sr(returns2) on paired return series
 
@@ -43,7 +46,8 @@ def sharpe_difference_test(returns1: pd.Series,
     n_lags: Optional[int]
         bartlett kernel truncation, the newey-west automatic rule when None
     af: float
-        annualisation factor of the return frequency for reporting, the t-statistic is scale-invariant
+        annualisation factor of the return frequency for reporting; the t-statistic is
+        scale-invariant
 
     Returns
     -------
@@ -69,14 +73,24 @@ def sharpe_difference_test(returns1: pd.Series,
     sr = mu / sigma
 
     # delta-method gradient of sr_1 - sr_2 in (mu_1, mu_2, gamma_1, gamma_2)
-    grad = np.array([gamma[0] / sigma[0] ** 3,
-                     -gamma[1] / sigma[1] ** 3,
-                     -0.5 * mu[0] / sigma[0] ** 3,
-                     0.5 * mu[1] / sigma[1] ** 3])
+    grad = np.array(
+        [
+            gamma[0] / sigma[0] ** 3,
+            -gamma[1] / sigma[1] ** 3,
+            -0.5 * mu[0] / sigma[0] ** 3,
+            0.5 * mu[1] / sigma[1] ** 3,
+        ]
+    )
 
     # hac covariance of the demeaned moment vector with a bartlett kernel
-    y = np.column_stack([r[:, 0] - mu[0], r[:, 1] - mu[1],
-                         np.square(r[:, 0]) - gamma[0], np.square(r[:, 1]) - gamma[1]])
+    y = np.column_stack(
+        [
+            r[:, 0] - mu[0],
+            r[:, 1] - mu[1],
+            np.square(r[:, 0]) - gamma[0],
+            np.square(r[:, 1]) - gamma[1],
+        ]
+    )
     if n_lags is None:
         n_lags = int(np.floor(4.0 * (n_obs / 100.0) ** (2.0 / 9.0)))
     psi = y.T @ y / n_obs
@@ -90,6 +104,13 @@ def sharpe_difference_test(returns1: pd.Series,
     t_stat = diff / se
     p_value = float(2.0 * (1.0 - norm.cdf(np.abs(t_stat))))
     sqrt_af = np.sqrt(af)
-    return SharpeDiffTest(sr1_an=float(sqrt_af * sr[0]), sr2_an=float(sqrt_af * sr[1]),
-                          diff_an=float(sqrt_af * diff), se_an=float(sqrt_af * se),
-                          t_stat=float(t_stat), p_value=p_value, n_obs=n_obs, n_lags=int(n_lags))
+    return SharpeDiffTest(
+        sr1_an=float(sqrt_af * sr[0]),
+        sr2_an=float(sqrt_af * sr[1]),
+        diff_an=float(sqrt_af * diff),
+        se_an=float(sqrt_af * se),
+        t_stat=float(t_stat),
+        p_value=p_value,
+        n_obs=n_obs,
+        n_lags=int(n_lags),
+    )

--- a/src/trendfollowing/backtests.py
+++ b/src/trendfollowing/backtests.py
@@ -6,6 +6,7 @@ implementation exhibits of the paper
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 import numpy as np
 import pandas as pd
 import qis as qis
@@ -19,96 +20,122 @@ from trendfollowing.systems.european import run_european_tf_system
 from trendfollowing.systems.tsmom import run_tsmom_system
 
 
-PERF_PARAMS = qis.PerfParams(freq_reg='W-WED', freq_vol='B', freq_drawdown='B',
-                             sharpe_convention=qis.perfstats.config.SharpeConvention.ARITHMETIC)
-regime_classifier = qis.BenchmarkReturnsQuantilesRegime(freq='QE', q=np.array([0.0, 0.16, 0.84, 1.0]))  # one-sigma 16/84 cut
+PERF_PARAMS = qis.PerfParams(
+    freq_reg='W-WED',
+    freq_vol='B',
+    freq_drawdown='B',
+    sharpe_convention=qis.perfstats.config.SharpeConvention.ARITHMETIC,
+)
+regime_classifier = qis.BenchmarkReturnsQuantilesRegime(
+    freq='QE', q=np.array([0.0, 0.16, 0.84, 1.0])
+)  # one-sigma 16/84 cut
 
 
 class TFstrategy(Enum):
     """
     enum of the three system designs
     """
+
     EUROPEAN = 1
     AMERICAN = 2
-    TSMOM  = 3
+    TSMOM = 3
 
 
-def joint_backtest(prices: pd.DataFrame,
-                   volume_costs: pd.DataFrame,
-                   benchmark_prices: pd.DataFrame,
-                   time_period: qis.TimePeriod = None
-                   ) -> plt.Figure:
-
+def joint_backtest(
+    prices: pd.DataFrame,
+    volume_costs: pd.DataFrame,
+    benchmark_prices: pd.DataFrame,
+    time_period: qis.TimePeriod = None,
+) -> plt.Figure:
     """
     run the european ls(250,20), the american, and the tsmom systems on common
     prices with volume-based costs and report them against the benchmarks
     """
-    e_backtest_outputs = run_european_tf_system(prices=prices,
-                                                long_span=250,
-                                                short_span=20,
-                                                vol_span=33,
-                                                vol_target=0.0035,
-                                                portfolio_covar_span=None,
-                                                portfolio_target_vol=0.15,
-                                                volume_costs=volume_costs)
+    e_backtest_outputs = run_european_tf_system(
+        prices=prices,
+        long_span=250,
+        short_span=20,
+        vol_span=33,
+        vol_target=0.0035,
+        portfolio_covar_span=None,
+        portfolio_target_vol=0.15,
+        volume_costs=volume_costs,
+    )
 
-    a_backtest_outputs = run_american_system(prices=prices,
-                                             risk_multiplier=0.0004,
-                                             vol_span=33,
-                                             portfolio_covar_span=None,
-                                             portfolio_target_vol=0.15,
-                                             volume_costs=volume_costs)
+    a_backtest_outputs = run_american_system(
+        prices=prices,
+        risk_multiplier=0.0004,
+        vol_span=33,
+        portfolio_covar_span=None,
+        portfolio_target_vol=0.15,
+        volume_costs=volume_costs,
+    )
 
-    tsmom_backtest_outputs = run_tsmom_system(prices=prices,
-                                              num_ra_returns=5,
-                                              num_periods=10,
-                                              vol_span=33,
-                                              vol_target=0.0035,
-                                              portfolio_covar_span=None,
-                                              portfolio_target_vol=0.15,
-                                              volume_costs=volume_costs)
+    tsmom_backtest_outputs = run_tsmom_system(
+        prices=prices,
+        num_ra_returns=5,
+        num_periods=10,
+        vol_span=33,
+        vol_target=0.0035,
+        portfolio_covar_span=None,
+        portfolio_target_vol=0.15,
+        volume_costs=volume_costs,
+    )
 
-    prices = pd.concat([benchmark_prices,
-                        e_backtest_outputs.portfolio_pnl.rename('European gross'),
-                        e_backtest_outputs.portfolio_pnl_net.rename('European net'),
-                        a_backtest_outputs.portfolio_pnl.rename('American gross'),
-                        a_backtest_outputs.portfolio_pnl_net.rename('American net'),
-                        tsmom_backtest_outputs.portfolio_pnl.rename('TSMOM gross'),
-                        tsmom_backtest_outputs.portfolio_pnl_net.rename('TSMOM net')
-                        ], axis=1, sort=True)
+    prices = pd.concat(
+        [
+            benchmark_prices,
+            e_backtest_outputs.portfolio_pnl.rename('European gross'),
+            e_backtest_outputs.portfolio_pnl_net.rename('European net'),
+            a_backtest_outputs.portfolio_pnl.rename('American gross'),
+            a_backtest_outputs.portfolio_pnl_net.rename('American net'),
+            tsmom_backtest_outputs.portfolio_pnl.rename('TSMOM gross'),
+            tsmom_backtest_outputs.portfolio_pnl_net.rename('TSMOM net'),
+        ],
+        axis=1,
+        sort=True,
+    )
 
-    fig = qis.generate_multi_asset_factsheet(prices=prices,
-                                             benchmark=benchmark_prices.columns[0],
-                                             time_period=time_period,
-                                             **qis.fetch_default_report_kwargs(time_period=time_period, add_rates_data=False))
-    df = pd.concat([benchmark_prices.iloc[:, -1],
-                    e_backtest_outputs.portfolio_pnl_net.rename('European net'),
-                    a_backtest_outputs.portfolio_pnl_net.rename('American net'),
-                    tsmom_backtest_outputs.portfolio_pnl_net.rename('TSMOM net')],
-                   axis=1, sort=True)
+    fig = qis.generate_multi_asset_factsheet(
+        prices=prices,
+        benchmark=benchmark_prices.columns[0],
+        time_period=time_period,
+        **qis.fetch_default_report_kwargs(time_period=time_period, add_rates_data=False),
+    )
+    df = pd.concat(
+        [
+            benchmark_prices.iloc[:, -1],
+            e_backtest_outputs.portfolio_pnl_net.rename('European net'),
+            a_backtest_outputs.portfolio_pnl_net.rename('American net'),
+            tsmom_backtest_outputs.portfolio_pnl_net.rename('TSMOM net'),
+        ],
+        axis=1,
+        sort=True,
+    )
 
-    qis.plot_returns_corr_matrix_time_series(prices=df, span=100,
-                                             time_period=time_period,
-                                             framealpha=0.9)
+    qis.plot_returns_corr_matrix_time_series(
+        prices=df, span=100, time_period=time_period, framealpha=0.9
+    )
 
     return fig
 
 
-def backtest_span_grid(prices: pd.DataFrame,
-                       volume_costs: pd.DataFrame,
-                       benchmark_prices: pd.DataFrame,
-                       tf_strategy: TFstrategy = TFstrategy.EUROPEAN,
-                       long_spans: List[int] = (30, 50, 75, 100, 175, 250, 375, 500),
-                       short_spans: List[int] = (5, 10, 20, 30, 40, 50, 75, 100),
-                       vol_span: int = 33,
-                       vol_target: float = 0.05,
-                       risk_multiplier: float = 0.0004,
-                       portfolio_covar_span: Optional[int] = 100,
-                       portfolio_target_vol: float = 0.15,
-                       annualization_factor: float = 260.0
-                       ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    #long_spans = (100, 250, 500)
-    #short_spans = (20, 40, 100)
+def backtest_span_grid(
+    prices: pd.DataFrame,
+    volume_costs: pd.DataFrame,
+    benchmark_prices: pd.DataFrame,
+    tf_strategy: TFstrategy = TFstrategy.EUROPEAN,
+    long_spans: List[int] = (30, 50, 75, 100, 175, 250, 375, 500),
+    short_spans: List[int] = (5, 10, 20, 30, 40, 50, 75, 100),
+    vol_span: int = 33,
+    vol_target: float = 0.05,
+    risk_multiplier: float = 0.0004,
+    portfolio_covar_span: Optional[int] = 100,
+    portfolio_target_vol: float = 0.15,
+    annualization_factor: float = 260.0,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    # long_spans = (100, 250, 500)
+    # short_spans = (20, 40, 100)
     """
     sharpe ratio, turnover, and costs of one system across the grid of long and short filter spans
     """
@@ -123,43 +150,53 @@ def backtest_span_grid(prices: pd.DataFrame,
         for idx2, short_span in enumerate(short_spans):
             if long_span > short_span:
                 if tf_strategy == TFstrategy.EUROPEAN:
-                    backtest_outputs = run_european_tf_system(prices=prices,
-                                                              long_span=long_span,
-                                                              short_span=short_span,
-                                                              vol_span=vol_span,
-                                                              vol_target=vol_target,
-                                                              portfolio_covar_span=portfolio_covar_span,
-                                                              portfolio_target_vol=portfolio_target_vol,
-                                                              annualization_factor=annualization_factor,
-                                                              volume_costs=volume_costs)
+                    backtest_outputs = run_european_tf_system(
+                        prices=prices,
+                        long_span=long_span,
+                        short_span=short_span,
+                        vol_span=vol_span,
+                        vol_target=vol_target,
+                        portfolio_covar_span=portfolio_covar_span,
+                        portfolio_target_vol=portfolio_target_vol,
+                        annualization_factor=annualization_factor,
+                        volume_costs=volume_costs,
+                    )
                 elif tf_strategy == TFstrategy.AMERICAN:
-                    backtest_outputs = run_american_system(prices=prices,
-                                                           long_span=long_span,
-                                                           short_span=short_span,
-                                                           vol_span=vol_span,
-                                                           stop_loss_atr_multiplier=5.0,
-                                                           signal_atr_multiplier=5.0,
-                                                           annualization_factor=annualization_factor,
-                                                           risk_multiplier=risk_multiplier,
-                                                           volume_costs=volume_costs)
+                    backtest_outputs = run_american_system(
+                        prices=prices,
+                        long_span=long_span,
+                        short_span=short_span,
+                        vol_span=vol_span,
+                        stop_loss_atr_multiplier=5.0,
+                        signal_atr_multiplier=5.0,
+                        annualization_factor=annualization_factor,
+                        risk_multiplier=risk_multiplier,
+                        volume_costs=volume_costs,
+                    )
                 else:
                     raise NotImplementedError(f"{tf_strategy}")
 
-                pnls[f"short={short_span:0.0f}"] = pd.Series(backtest_outputs.portfolio_pnl_net, index=prices.index)
-                costs_[f"short={short_span:0.0f}"] = pd.Series(backtest_outputs.portfolio_cost, index=prices.index)
+                pnls[f"short={short_span:0.0f}"] = pd.Series(
+                    backtest_outputs.portfolio_pnl_net, index=prices.index
+                )
+                costs_[f"short={short_span:0.0f}"] = pd.Series(
+                    backtest_outputs.portfolio_cost, index=prices.index
+                )
 
         pnls = pd.DataFrame.from_dict(pnls, orient='columns')
         prices1 = pd.concat([benchmark_prices[benchmark], pnls], axis=1, sort=True)
         costs_ = pd.DataFrame.from_dict(costs_, orient='columns')
 
-        ra_perf_table = qis.compute_bnb_regimes_pa_perf_table(prices=prices1,
-                                                              benchmark=benchmark,
-                                                              regime_classifier=regime_classifier,
-                                                              perf_params=PERF_PARAMS)
+        ra_perf_table = qis.compute_bnb_regimes_pa_perf_table(
+            prices=prices1,
+            benchmark=benchmark,
+            regime_classifier=regime_classifier,
+            perf_params=PERF_PARAMS,
+        )
 
         net_sharpes[f"long={long_span:0.0f}"] = ra_perf_table[qis.PerfStat.SHARPE_ARITH.to_str()]
         bear_sharpes[f"long={long_span:0.0f}"] = ra_perf_table[qis.PerfStat.BEAR_SHARPE.to_str()]
-        costs[f"long={long_span:0.0f}"] = annualization_factor*costs_.mean(axis=0)
+        costs[f"long={long_span:0.0f}"] = annualization_factor * costs_.mean(axis=0)
 
     net_sharpes = pd.DataFrame.from_dict(net_sharpes, orient='index').drop(benchmark, axis=1)
     bear_sharpes = pd.DataFrame.from_dict(bear_sharpes, orient='index').drop(benchmark, axis=1)
@@ -168,20 +205,21 @@ def backtest_span_grid(prices: pd.DataFrame,
     return net_sharpes, bear_sharpes, costs
 
 
-def backtest_american_atr_multiplies_grid(prices: pd.DataFrame,
-                                          volume_costs: pd.DataFrame,
-                                          benchmark_prices: pd.DataFrame,
-                                          stop_loss_atr_multipliers: List[float] = np.linspace(0.5, 7.5, 8),
-                                          signal_atr_multipliers: List[float] = np.linspace(0.5, 7.5, 8),
-                                          long_span: int = 250,
-                                          short_span: int = 50,
-                                          vol_span: int = 33,
-                                          vol_target: float = 0.05,
-                                          risk_multiplier: float = 0.0004,
-                                          portfolio_covar_span: Optional[int] = 100,
-                                          portfolio_target_vol: float = 0.15,
-                                          annualization_factor: float = 260.0
-                                          ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def backtest_american_atr_multiplies_grid(
+    prices: pd.DataFrame,
+    volume_costs: pd.DataFrame,
+    benchmark_prices: pd.DataFrame,
+    stop_loss_atr_multipliers: List[float] = np.linspace(0.5, 7.5, 8),
+    signal_atr_multipliers: List[float] = np.linspace(0.5, 7.5, 8),
+    long_span: int = 250,
+    short_span: int = 50,
+    vol_span: int = 33,
+    vol_target: float = 0.05,
+    risk_multiplier: float = 0.0004,
+    portfolio_covar_span: Optional[int] = 100,
+    portfolio_target_vol: float = 0.15,
+    annualization_factor: float = 260.0,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     performance of the american system across the grid of atr risk multipliers
     """
@@ -193,76 +231,85 @@ def backtest_american_atr_multiplies_grid(prices: pd.DataFrame,
         pnls = {}
         costs_ = {}
         for idx2, signal_atr_multiplier in enumerate(signal_atr_multipliers):
-            backtest_outputs = run_american_system(prices=prices,
-                                                   long_span=long_span,
-                                                   short_span=short_span,
-                                                   vol_span=vol_span,
-                                                   stop_loss_atr_multiplier=stop_loss_atr_multiplier,
-                                                   signal_atr_multiplier=signal_atr_multiplier,
-                                                   annualization_factor=annualization_factor,
-                                                   risk_multiplier=risk_multiplier,
-                                                   volume_costs=volume_costs)
+            backtest_outputs = run_american_system(
+                prices=prices,
+                long_span=long_span,
+                short_span=short_span,
+                vol_span=vol_span,
+                stop_loss_atr_multiplier=stop_loss_atr_multiplier,
+                signal_atr_multiplier=signal_atr_multiplier,
+                annualization_factor=annualization_factor,
+                risk_multiplier=risk_multiplier,
+                volume_costs=volume_costs,
+            )
             key2 = f"signal q={signal_atr_multiplier:0.2f}"
             pnls[key2] = pd.Series(backtest_outputs.portfolio_pnl_net, index=prices.index)
             costs_[key2] = pd.Series(backtest_outputs.portfolio_cost, index=prices.index)
         pnls = pd.DataFrame.from_dict(pnls, orient='columns')
         costs_ = pd.DataFrame.from_dict(costs_, orient='columns')
         prices1 = pd.concat([benchmark_prices[benchmark], pnls], axis=1, sort=True)
-        ra_perf_table = qis.compute_bnb_regimes_pa_perf_table(prices=prices1,
-                                                              benchmark=benchmark,
-                                                              regime_classifier=regime_classifier,
-                                                              perf_params=PERF_PARAMS)
+        ra_perf_table = qis.compute_bnb_regimes_pa_perf_table(
+            prices=prices1,
+            benchmark=benchmark,
+            regime_classifier=regime_classifier,
+            perf_params=PERF_PARAMS,
+        )
         key1 = f"stop-loss p={stop_loss_atr_multiplier:0.2f}"
         net_sharpes[key1] = ra_perf_table[qis.PerfStat.SHARPE_ARITH.to_str()]
         bear_sharpes[key1] = ra_perf_table[qis.PerfStat.BEAR_SHARPE.to_str()]
-        costs[key1] = annualization_factor*costs_.mean(axis=0)
+        costs[key1] = annualization_factor * costs_.mean(axis=0)
     net_sharpes = pd.DataFrame.from_dict(net_sharpes, orient='index').drop(benchmark, axis=1)
     bear_sharpes = pd.DataFrame.from_dict(bear_sharpes, orient='index').drop(benchmark, axis=1)
     costs = pd.DataFrame.from_dict(costs, orient='index')
     return net_sharpes, bear_sharpes, costs
 
 
-def cross_backtest_portfolio_covar_span(prices: pd.DataFrame,
-                                        portfolio_covar_spans: List[Optional[int]] = (None, 30, 60, 90, 130, 260, 520),
-                                        tf_strategy: TFstrategy = TFstrategy.EUROPEAN,
-                                        long_span: int = 250,
-                                        short_span: Optional[int] = 20,
-                                        vol_span: int = 33,
-                                        vol_target: float = 0.05,
-                                        risk_multiplier: float = 0.0004,
-                                        portfolio_covar_span: Optional[int] = None,
-                                        portfolio_target_vol: float = 0.15,
-                                        annualization_factor: float = 260.0,
-                                        volume_costs: Union[float, pd.DataFrame] = 0.0010,
-                                        time_period: qis.TimePeriod = None
-                                        ) -> pd.DataFrame:
+def cross_backtest_portfolio_covar_span(
+    prices: pd.DataFrame,
+    portfolio_covar_spans: List[Optional[int]] = (None, 30, 60, 90, 130, 260, 520),
+    tf_strategy: TFstrategy = TFstrategy.EUROPEAN,
+    long_span: int = 250,
+    short_span: Optional[int] = 20,
+    vol_span: int = 33,
+    vol_target: float = 0.05,
+    risk_multiplier: float = 0.0004,
+    portfolio_covar_span: Optional[int] = None,
+    portfolio_target_vol: float = 0.15,
+    annualization_factor: float = 260.0,
+    volume_costs: Union[float, pd.DataFrame] = 0.0010,
+    time_period: qis.TimePeriod = None,
+) -> pd.DataFrame:
     """
-    performance of one system across the portfolio covariance spans of the portfolio-level volatility targeting
+    performance of one system across the portfolio covariance spans of the
+    portfolio-level volatility targeting
     """
     pnls = {}
     for portfolio_covar_span in portfolio_covar_spans:
         if tf_strategy == TFstrategy.EUROPEAN:
-            backtest_outputs = run_european_tf_system(prices=prices,
-                                                      long_span=long_span,
-                                                      short_span=short_span,
-                                                      vol_span=portfolio_covar_span or vol_span,
-                                                      vol_target=vol_target,
-                                                      portfolio_covar_span=portfolio_covar_span,
-                                                      portfolio_target_vol=portfolio_target_vol,
-                                                      annualization_factor=annualization_factor,
-                                                      volume_costs=volume_costs)
+            backtest_outputs = run_european_tf_system(
+                prices=prices,
+                long_span=long_span,
+                short_span=short_span,
+                vol_span=portfolio_covar_span or vol_span,
+                vol_target=vol_target,
+                portfolio_covar_span=portfolio_covar_span,
+                portfolio_target_vol=portfolio_target_vol,
+                annualization_factor=annualization_factor,
+                volume_costs=volume_costs,
+            )
         elif tf_strategy == TFstrategy.AMERICAN:
-            backtest_outputs = run_american_system(prices=prices,
-                                                   long_span=long_span,
-                                                   short_span=short_span,
-                                                   portfolio_covar_span=portfolio_covar_span,
-                                                   risk_multiplier=risk_multiplier,
-                                                   volume_costs=volume_costs
-                                                   )
+            backtest_outputs = run_american_system(
+                prices=prices,
+                long_span=long_span,
+                short_span=short_span,
+                portfolio_covar_span=portfolio_covar_span,
+                risk_multiplier=risk_multiplier,
+                volume_costs=volume_costs,
+            )
         elif tf_strategy == TFstrategy.TSMOM:
-            backtest_outputs = run_tsmom_system(prices=prices,
-                                                portfolio_covar_span=portfolio_covar_span,
-                                                volume_costs=volume_costs)
+            backtest_outputs = run_tsmom_system(
+                prices=prices, portfolio_covar_span=portfolio_covar_span, volume_costs=volume_costs
+            )
 
         else:
             raise NotImplementedError(f"{tf_strategy}")
@@ -278,18 +325,18 @@ def cross_backtest_portfolio_covar_span(prices: pd.DataFrame,
     return pnls
 
 
-def backtest_tsmom_grid(prices: pd.DataFrame,
-                        volume_costs: pd.DataFrame,
-                        benchmark_prices: pd.DataFrame,
-                        num_ra_returnss: List[int] = np.linspace(3, 27, 8, dtype=int),
-                        num_periodss: List[int] = np.linspace(3, 27, 8, dtype=int),
-                        vol_span: int = 33,
-                        vol_target: float = 0.004,
-                        portfolio_covar_span: Optional[int] = None,
-                        portfolio_target_vol: float = 0.15,
-                        annualization_factor: float = 260.0
-                        ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-
+def backtest_tsmom_grid(
+    prices: pd.DataFrame,
+    volume_costs: pd.DataFrame,
+    benchmark_prices: pd.DataFrame,
+    num_ra_returnss: List[int] = np.linspace(3, 27, 8, dtype=int),
+    num_periodss: List[int] = np.linspace(3, 27, 8, dtype=int),
+    vol_span: int = 33,
+    vol_target: float = 0.004,
+    portfolio_covar_span: Optional[int] = None,
+    portfolio_target_vol: float = 0.15,
+    annualization_factor: float = 260.0,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     performance of the tsmom system across the grid of period lengths and lookbacks
     """
@@ -302,15 +349,17 @@ def backtest_tsmom_grid(prices: pd.DataFrame,
         pnls = {}
         costs_ = {}
         for idx2, num_ra_returns in enumerate(num_ra_returnss):
-            backtest_outputs = run_tsmom_system(prices=prices,
-                                                num_ra_returns=int(num_ra_returns),
-                                                num_periods=int(num_periods),
-                                                vol_span=vol_span,
-                                                vol_target=vol_target,
-                                                portfolio_covar_span=portfolio_covar_span,
-                                                portfolio_target_vol=portfolio_target_vol,
-                                                volume_costs=volume_costs,
-                                                annualization_factor=annualization_factor)
+            backtest_outputs = run_tsmom_system(
+                prices=prices,
+                num_ra_returns=int(num_ra_returns),
+                num_periods=int(num_periods),
+                vol_span=vol_span,
+                vol_target=vol_target,
+                portfolio_covar_span=portfolio_covar_span,
+                portfolio_target_vol=portfolio_target_vol,
+                volume_costs=volume_costs,
+                annualization_factor=annualization_factor,
+            )
             key2 = f"L returns={num_ra_returns:0.0f}"
             pnls[key2] = pd.Series(backtest_outputs.portfolio_pnl_net, index=prices.index)
             costs_[key2] = pd.Series(backtest_outputs.portfolio_cost, index=prices.index)
@@ -318,14 +367,16 @@ def backtest_tsmom_grid(prices: pd.DataFrame,
         pnls = pd.DataFrame.from_dict(pnls, orient='columns')
         prices1 = pd.concat([benchmark_prices[benchmark], pnls], axis=1, sort=True)
         costs_ = pd.DataFrame.from_dict(costs_, orient='columns')
-        ra_perf_table = qis.compute_bnb_regimes_pa_perf_table(prices=prices1,
-                                                              benchmark=benchmark,
-                                                              regime_classifier=regime_classifier,
-                                                              perf_params=PERF_PARAMS)
+        ra_perf_table = qis.compute_bnb_regimes_pa_perf_table(
+            prices=prices1,
+            benchmark=benchmark,
+            regime_classifier=regime_classifier,
+            perf_params=PERF_PARAMS,
+        )
         key1 = f"M periods={num_periods:0.0f}"
         net_sharpes[key1] = ra_perf_table[qis.PerfStat.SHARPE_ARITH.to_str()]
         bear_sharpes[key1] = ra_perf_table[qis.PerfStat.BEAR_SHARPE.to_str()]
-        costs[key1] = annualization_factor*costs_.mean(axis=0)
+        costs[key1] = annualization_factor * costs_.mean(axis=0)
 
     net_sharpes = pd.DataFrame.from_dict(net_sharpes, orient='index').drop(benchmark, axis=1)
     bear_sharpes = pd.DataFrame.from_dict(bear_sharpes, orient='index').drop(benchmark, axis=1)
@@ -341,28 +392,33 @@ def plot_backtest(pnl, net_pnl, turnover, costs, weights):
         fig, axs = plt.subplots(2, 2, figsize=(15, 12), tight_layout=True)
 
         pnls = pd.concat([pnl, net_pnl.rename('net')], axis=1, sort=True)
-        qis.plot_prices_with_dd(prices=pnls,
-                                axs=axs[:, 0])
-        qis.plot_time_series(df=turnover.rolling(250).sum(),
-                             var_format='{:,.0%}', title='annual turnover',
-                             ax=axs[0, 1])
-        qis.plot_time_series(df=costs.rolling(250).sum(),
-                             var_format='{:,.2%}', title='annual costs',
-                             ax=axs[1, 1])
+        qis.plot_prices_with_dd(prices=pnls, axs=axs[:, 0])
+        qis.plot_time_series(
+            df=turnover.rolling(250).sum(),
+            var_format='{:,.0%}',
+            title='annual turnover',
+            ax=axs[0, 1],
+        )
+        qis.plot_time_series(
+            df=costs.rolling(250).sum(), var_format='{:,.2%}', title='annual costs', ax=axs[1, 1]
+        )
 
 
-def plot_grid_backtest(prices: pd.DataFrame,
-                       volume_costs: pd.DataFrame,
-                       benchmark_prices: pd.DataFrame,
-                       tf_strategy: TFstrategy = TFstrategy.EUROPEAN
-                       ) -> None:
+def plot_grid_backtest(
+    prices: pd.DataFrame,
+    volume_costs: pd.DataFrame,
+    benchmark_prices: pd.DataFrame,
+    tf_strategy: TFstrategy = TFstrategy.EUROPEAN,
+) -> None:
     """
     render the grid backtest tables as figures
     """
-    net_sharpes, bear_sharpes, costs = backtest_span_grid(prices=prices,
-                                                          volume_costs=volume_costs,
-                                                          benchmark_prices=benchmark_prices,
-                                                          tf_strategy=tf_strategy)
+    net_sharpes, bear_sharpes, costs = backtest_span_grid(
+        prices=prices,
+        volume_costs=volume_costs,
+        benchmark_prices=benchmark_prices,
+        tf_strategy=tf_strategy,
+    )
     qis.plot_heatmap(df=net_sharpes, var_format='{:.2f}', title='Net Sharpe')
     qis.plot_heatmap(df=bear_sharpes, var_format='{:.2f}', title='Bear Sharpe')
     qis.plot_heatmap(df=costs, var_format='{:.2f}', title='Bear Sharpe')
@@ -372,6 +428,7 @@ class LocalTests(Enum):
     """
     runnable example cases
     """
+
     RUN_EUROPEAN = 1
     RUN_AMERICAN = 2
     RUN_TSMOM = 3
@@ -396,75 +453,94 @@ def run_local_test(local_test: LocalTests):
     perf_time_period = qis.TimePeriod(start='31Dec1999', end='25Apr2025')
 
     from trendfollowing.universe import load_data
-    prices, volume_costs, benchmark_prices, group_data, group_order = load_data(time_period=time_period)
+
+    prices, volume_costs, benchmark_prices, group_data, group_order = load_data(
+        time_period=time_period
+    )
 
     if local_test == LocalTests.RUN_EUROPEAN:
-        backtest_outputs = run_european_tf_system(prices=prices,
-                                                  long_span=250,
-                                                  short_span=20,
-                                                  vol_span=33,
-                                                  vol_target=0.05,
-                                                  portfolio_covar_span=250,
-                                                  portfolio_target_vol=0.15,
-                                                  volume_costs=volume_costs)
-        plot_backtest(backtest_outputs.portfolio_pnl,
-                      backtest_outputs.portfolio_pnl_net,
-                      backtest_outputs.portfolio_turnover,
-                      backtest_outputs.portfolio_cost,
-                      backtest_outputs.weights)
+        backtest_outputs = run_european_tf_system(
+            prices=prices,
+            long_span=250,
+            short_span=20,
+            vol_span=33,
+            vol_target=0.05,
+            portfolio_covar_span=250,
+            portfolio_target_vol=0.15,
+            volume_costs=volume_costs,
+        )
+        plot_backtest(
+            backtest_outputs.portfolio_pnl,
+            backtest_outputs.portfolio_pnl_net,
+            backtest_outputs.portfolio_turnover,
+            backtest_outputs.portfolio_cost,
+            backtest_outputs.weights,
+        )
 
     elif local_test == LocalTests.RUN_AMERICAN:
-        #prices = prices['ES1 Index'].to_frame().dropna()
+        # prices = prices['ES1 Index'].to_frame().dropna()
         # price = prices['TY1 Comdty'].dropna()
         # price = prices['QC1 Comdty'].dropna()
-        prices = prices#.iloc[:, :15]
-        pnl, net_pnl, turnover, costs, weights = run_american_system(prices=prices,
-                                                                     risk_multiplier=0.0004,
-                                                                     volume_costs=volume_costs)
+        prices = prices  # .iloc[:, :15]
+        pnl, net_pnl, turnover, costs, weights = run_american_system(
+            prices=prices, risk_multiplier=0.0004, volume_costs=volume_costs
+        )
         plot_backtest(pnl, net_pnl, turnover, costs, weights)
 
     elif local_test == LocalTests.RUN_TSMOM:
-        backtest_outputs = run_tsmom_system(prices=prices,
-                                            num_ra_returns=22,
-                                            num_periods=12,
-                                            vol_span=31,
-                                            vol_target=0.05,
-                                            portfolio_covar_span=250,
-                                            portfolio_target_vol=0.15,
-                                            volume_costs=volume_costs)
-        plot_backtest(backtest_outputs.portfolio_pnl,
-                      backtest_outputs.portfolio_pnl_net,
-                      backtest_outputs.portfolio_turnover,
-                      backtest_outputs.portfolio_cost,
-                      backtest_outputs.weights)
+        backtest_outputs = run_tsmom_system(
+            prices=prices,
+            num_ra_returns=22,
+            num_periods=12,
+            vol_span=31,
+            vol_target=0.05,
+            portfolio_covar_span=250,
+            portfolio_target_vol=0.15,
+            volume_costs=volume_costs,
+        )
+        plot_backtest(
+            backtest_outputs.portfolio_pnl,
+            backtest_outputs.portfolio_pnl_net,
+            backtest_outputs.portfolio_turnover,
+            backtest_outputs.portfolio_cost,
+            backtest_outputs.weights,
+        )
 
     elif local_test == LocalTests.JOINT_BACKTEST:
-        fig = joint_backtest(prices=prices,
-                             volume_costs=volume_costs,
-                             benchmark_prices=benchmark_prices,
-                             time_period=perf_time_period)
-        qis.save_figs_to_pdf(figs=[fig],
-                             file_name=f"tf_system", orientation='landscape',
-                             local_path=qis.get_output_path()
-                             )
+        fig = joint_backtest(
+            prices=prices,
+            volume_costs=volume_costs,
+            benchmark_prices=benchmark_prices,
+            time_period=perf_time_period,
+        )
+        qis.save_figs_to_pdf(
+            figs=[fig],
+            file_name="tf_system",
+            orientation='landscape',
+            local_path=qis.get_output_path(),
+        )
 
     elif local_test == LocalTests.GRID_BACKTEST:
-        plot_grid_backtest(prices=prices,
-                           volume_costs=volume_costs,
-                           benchmark_prices=benchmark_prices,
-                           tf_strategy=TFstrategy.EUROPEAN)
+        plot_grid_backtest(
+            prices=prices,
+            volume_costs=volume_costs,
+            benchmark_prices=benchmark_prices,
+            tf_strategy=TFstrategy.EUROPEAN,
+        )
 
     elif local_test == LocalTests.AMERICAN_MULTIPLIERS:
-        net_sharpes, bear_sharpes, costs = backtest_american_atr_multiplies_grid(prices=prices,
-                                                                          volume_costs=volume_costs,
-                                                                          benchmark_prices=benchmark_prices,
-                                                                          risk_multiplier=0.0004)
+        net_sharpes, bear_sharpes, costs = backtest_american_atr_multiplies_grid(
+            prices=prices,
+            volume_costs=volume_costs,
+            benchmark_prices=benchmark_prices,
+            risk_multiplier=0.0004,
+        )
         qis.plot_heatmap(net_sharpes, var_format='{:.2f}')
 
     elif local_test == LocalTests.TSMOM_GRID:
-        net_sharpes, bear_sharpes, costs = backtest_tsmom_grid(prices=prices,
-                                                        volume_costs=volume_costs,
-                                                        benchmark_prices=benchmark_prices)
+        net_sharpes, bear_sharpes, costs = backtest_tsmom_grid(
+            prices=prices, volume_costs=volume_costs, benchmark_prices=benchmark_prices
+        )
         print(net_sharpes)
         qis.plot_heatmap(net_sharpes, var_format='{:.2f}')
         qis.plot_heatmap(bear_sharpes, var_format='{:.2f}')
@@ -474,5 +550,4 @@ def run_local_test(local_test: LocalTests):
 
 
 if __name__ == '__main__':
-
     run_local_test(local_test=LocalTests.JOINT_BACKTEST)

--- a/src/trendfollowing/processes/path_engine.py
+++ b/src/trendfollowing/processes/path_engine.py
@@ -30,62 +30,54 @@ class ProcessType(Enum):
     """
     enum of the supported return-generating processes
     """
+
     WHITE_NOISE = 1
     AR_P = 2
     MA_Q = 3
     ARFIMA = 4
 
 
-def generate_paths(process_type: ProcessType = ProcessType.AR_P,
-                   phi: Union[np.ndarray, float] = None,
-                   ar_params: Optional[List[float]] = None,
-                   delta: float = 0.1,
-                   x0: np.ndarray = None,
-                   n_path: int = 1,
-                   m_times: int = 100,
-                   mean: float = 0.0,
-                   noise_std: float = 1.0,
-                   dt: float = 1.0
-                   ) -> np.ndarray:
-
+def generate_paths(
+    process_type: ProcessType = ProcessType.AR_P,
+    phi: Union[np.ndarray, float] = None,
+    ar_params: Optional[List[float]] = None,
+    delta: float = 0.1,
+    x0: np.ndarray = None,
+    n_path: int = 1,
+    m_times: int = 100,
+    mean: float = 0.0,
+    noise_std: float = 1.0,
+    dt: float = 1.0,
+) -> np.ndarray:
     """
     dispatch the path simulation by process type with common shape and seed handling
     """
     if ar_params is None:
         ar_params = [0.0]
     if process_type == ProcessType.WHITE_NOISE:
-        paths = simulate_white_noise_paths(x0=x0,
-                                           n_path=n_path,
-                                           m_times=m_times,
-                                           mean=mean,
-                                           noise_std=noise_std,
-                                           dt=dt)
+        paths = simulate_white_noise_paths(
+            x0=x0, n_path=n_path, m_times=m_times, mean=mean, noise_std=noise_std, dt=dt
+        )
     elif process_type == ProcessType.AR_P:
-        paths = simulate_ar_p_paths(phi=phi,
-                                    x0=x0,
-                                    n_path=n_path,
-                                    m_times=m_times,
-                                    mean=mean,
-                                    noise_std=noise_std,
-                                    dt=dt)
+        paths = simulate_ar_p_paths(
+            phi=phi, x0=x0, n_path=n_path, m_times=m_times, mean=mean, noise_std=noise_std, dt=dt
+        )
 
     elif process_type == ProcessType.MA_Q:
-        paths = simulate_ma_q_paths(phi=phi,
-                                    x0=x0,
-                                    n_path=n_path,
-                                    m_times=m_times,
-                                    drift=mean,
-                                    noise_std=noise_std,
-                                    dt=dt)
+        paths = simulate_ma_q_paths(
+            phi=phi, x0=x0, n_path=n_path, m_times=m_times, drift=mean, noise_std=noise_std, dt=dt
+        )
 
     elif process_type == ProcessType.ARFIMA:
-        paths = simulate_arfima_paths(ar_params=ar_params,
-                                      d=delta,
-                                      n_path=n_path,
-                                      m_times=m_times,
-                                      mean=mean,
-                                      noise_std=noise_std,
-                                      dt=dt)
+        paths = simulate_arfima_paths(
+            ar_params=ar_params,
+            d=delta,
+            n_path=n_path,
+            m_times=m_times,
+            mean=mean,
+            noise_std=noise_std,
+            dt=dt,
+        )
     else:
         raise NotImplementedError
 
@@ -93,36 +85,37 @@ def generate_paths(process_type: ProcessType = ProcessType.AR_P,
 
 
 @njit
-def simulate_white_noise_paths(x0: np.ndarray = None,
-                               n_path: int = 1,
-                               m_times: int = 100,
-                               mean: float = 0.0,
-                               noise_std: float = 1.0,
-                               dt: float = 1.0
-                               ) -> np.ndarray:
+def simulate_white_noise_paths(
+    x0: np.ndarray = None,
+    n_path: int = 1,
+    m_times: int = 100,
+    mean: float = 0.0,
+    noise_std: float = 1.0,
+    dt: float = 1.0,
+) -> np.ndarray:
     """
     white noise returns
     """
-    noise = np.sqrt(dt)*np.random.normal(0.0, noise_std, size=(m_times, n_path))
+    noise = np.sqrt(dt) * np.random.normal(0.0, noise_std, size=(m_times, n_path))
     drift_dt = mean * dt
     xt = drift_dt + noise
     return xt
 
 
 @njit
-def simulate_ar_p_paths(phi: np.ndarray,
-                        x0: np.ndarray = None,
-                        n_path: int = 1,
-                        m_times: int = 100,
-                        mean: float = 0.0,
-                        noise_std: float = 1.0,
-                        dt: float = 1.0
-                        ) -> np.ndarray:
-
+def simulate_ar_p_paths(
+    phi: np.ndarray,
+    x0: np.ndarray = None,
+    n_path: int = 1,
+    m_times: int = 100,
+    mean: float = 0.0,
+    noise_std: float = 1.0,
+    dt: float = 1.0,
+) -> np.ndarray:
     """
     simulate ar(p) paths x_t = c + sum_i phi_i x_{t-i} + noise_std eps_t
     """
-    noise = np.sqrt(dt)*np.random.normal(0.0, noise_std, size=(m_times, n_path))
+    noise = np.sqrt(dt) * np.random.normal(0.0, noise_std, size=(m_times, n_path))
     drift_dt = mean * dt
     p = phi.shape[0]
     if x0 is None:
@@ -134,25 +127,25 @@ def simulate_ar_p_paths(phi: np.ndarray,
 
     phi_ = np.ascontiguousarray(phi[::-1].T)  # revert, diable NumbaPerformanceWarning
     for t in np.arange(p, m_times):
-        xt[t, :] = drift_dt + phi_ @ np.ascontiguousarray(xt[t-p: t, :]) + noise[t, :]
+        xt[t, :] = drift_dt + phi_ @ np.ascontiguousarray(xt[t - p : t, :]) + noise[t, :]
 
     return xt
 
 
 @njit
-def simulate_ma_q_paths(phi: np.ndarray,
-                        x0: np.ndarray = None,
-                        n_path: int = 1,
-                        m_times: int = 100,
-                        mean: float = 0.0,
-                        noise_std: float = 1.0,
-                        dt: float = 1.0
-                        ) -> np.ndarray:
-
+def simulate_ma_q_paths(
+    phi: np.ndarray,
+    x0: np.ndarray = None,
+    n_path: int = 1,
+    m_times: int = 100,
+    mean: float = 0.0,
+    noise_std: float = 1.0,
+    dt: float = 1.0,
+) -> np.ndarray:
     """
     simulate ma(q) paths x_t = c + eps_t + sum_i theta_i eps_{t-i}
     """
-    noise = np.sqrt(dt)*np.random.normal(0.0, noise_std, size=(m_times, n_path))
+    noise = np.sqrt(dt) * np.random.normal(0.0, noise_std, size=(m_times, n_path))
     drift_dt = mean * dt
     p = phi.shape[0]
     if x0 is None:
@@ -164,28 +157,30 @@ def simulate_ma_q_paths(phi: np.ndarray,
 
     phi_ = np.ascontiguousarray(phi[::-1].T)  # revert, diable NumbaPerformanceWarning
     for t in np.arange(p, m_times):
-        xt[t, :] = drift_dt + phi_ @ np.ascontiguousarray(noise[t-p: t, :]) + noise[t, :]
+        xt[t, :] = drift_dt + phi_ @ np.ascontiguousarray(noise[t - p : t, :]) + noise[t, :]
 
     return xt
 
 
-def simulate_arfima_paths(ar_params: Optional[List[float]] = None,
-                          d: float = 0.15,
-                          n_path: int = 1,
-                          m_times: int = 100,
-                          mean: float = 0.0,
-                          noise_std: float = 1.0,
-                          dt: float = 1.0
-                          ) -> np.ndarray:
-
+def simulate_arfima_paths(
+    ar_params: Optional[List[float]] = None,
+    d: float = 0.15,
+    n_path: int = 1,
+    m_times: int = 100,
+    mean: float = 0.0,
+    noise_std: float = 1.0,
+    dt: float = 1.0,
+) -> np.ndarray:
     """
     simulate arfima(p,d,q) paths via the fractional-differencing engine of processes.arfima
     """
     noise = np.zeros((m_times, n_path))
     drift_dt = mean * dt
     for n in range(n_path):
-        noise[:, n] = arfima.arfima(ar_params=ar_params, d=d, ma_params=[], n_points=m_times, warmup=2 ** 16)
-    xt = drift_dt + np.sqrt(dt)*noise_std*noise
+        noise[:, n] = arfima.arfima(
+            ar_params=ar_params, d=d, ma_params=[], n_points=m_times, warmup=2**16
+        )
+    xt = drift_dt + np.sqrt(dt) * noise_std * noise
     return xt
 
 
@@ -193,6 +188,7 @@ class LocalTests(Enum):
     """
     runnable example cases
     """
+
     AR1 = 1
     ARFIMA = 2
 
@@ -212,23 +208,17 @@ def run_local_test(local_test: LocalTests):
     if local_test == LocalTests.AR1:
         phi = np.array([0.5])
         x0 = np.array([0.0])
-        #phi = np.array([-0.6, 0.3])
-        #x0 = np.array([0.0, 0.0])
+        # phi = np.array([-0.6, 0.3])
+        # x0 = np.array([0.0, 0.0])
 
-        paths = simulate_ar_p_paths(phi=phi,
-                                    x0=x0,
-                                    n_path=n_path,
-                                    m_times=m_times,
-                                    mean=0.0,
-                                    noise_std=1.0)
+        paths = simulate_ar_p_paths(
+            phi=phi, x0=x0, n_path=n_path, m_times=m_times, mean=0.0, noise_std=1.0
+        )
 
     elif local_test == LocalTests.ARFIMA:
-        paths = simulate_arfima_paths(ar_params=[0.0],
-                                      d=0.1,
-                                      n_path=n_path,
-                                      m_times=m_times,
-                                      mean=0.0,
-                                      noise_std=1.0)
+        paths = simulate_arfima_paths(
+            ar_params=[0.0], d=0.1, n_path=n_path, m_times=m_times, mean=0.0, noise_std=1.0
+        )
 
     else:
         raise NotImplementedError
@@ -243,7 +233,7 @@ def run_local_test(local_test: LocalTests):
     fig, axs = plt.subplots(2, 2, figsize=(18, 10), tight_layout=True)
     qis.plot_line(df=paths.iloc[:, :n_path_cut], ax=axs[0][0])
     qis.plot_histogram(df=paths.iloc[:, :n_path_cut], ax=axs[0][1])
-    plot_pacf(paths.iloc[:, 0], lags=10, title=f"path0", ax=axs[1][0])
+    plot_pacf(paths.iloc[:, 0], lags=10, title="path0", ax=axs[1][0])
     # peb.errorbar(df=m_acf, y_std_errors=std_acf, var_format='{:.2%}', ax=axs[1][1])
     qis.df_boxplot_by_index(df=acfs, ax=axs[1][1])
     print(pacf(paths.iloc[:, 0], nlags=10))
@@ -252,5 +242,4 @@ def run_local_test(local_test: LocalTests):
 
 
 if __name__ == '__main__':
-
     run_local_test(local_test=LocalTests.ARFIMA)

--- a/src/trendfollowing/systems/american.py
+++ b/src/trendfollowing/systems/american.py
@@ -6,6 +6,7 @@ trade inception
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 import numpy as np
 import pandas as pd
 import qis as qis
@@ -17,16 +18,17 @@ from trendfollowing.systems.backtest_utils import compute_pnl, compute_vol, Back
 
 
 @njit
-def run_american_on_instrument(price: np.ndarray,
-                               long_ewma: np.ndarray,
-                               short_ewma: np.ndarray,
-                               true_range: np.ndarray,
-                               risk_multiplier: float = 0.01,
-                               stop_loss_atr_multiplier: float = 10.0,
-                               signal_atr_multiplier: float = 5.0,
-                               weight_abs_limit: float = 5.0,
-                               warmup_period: int = 250
-                               ) -> Tuple[np.ndarray, np.ndarray]:
+def run_american_on_instrument(
+    price: np.ndarray,
+    long_ewma: np.ndarray,
+    short_ewma: np.ndarray,
+    true_range: np.ndarray,
+    risk_multiplier: float = 0.01,
+    stop_loss_atr_multiplier: float = 10.0,
+    signal_atr_multiplier: float = 5.0,
+    weight_abs_limit: float = 5.0,
+    warmup_period: int = 250,
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     american
     """
@@ -48,15 +50,23 @@ def run_american_on_instrument(price: np.ndarray,
                 short_ewma_t = short_ewma[t]
                 long_ewma_t = long_ewma[t]
 
-                is_fast_above_slow = True if short_ewma_t > long_ewma_t + signal_atr_multiplier*true_range_t_1 else False
-                is_fast_below_slow = True if short_ewma_t < long_ewma_t - signal_atr_multiplier*true_range_t_1 else False
+                is_fast_above_slow = (
+                    True
+                    if short_ewma_t > long_ewma_t + signal_atr_multiplier * true_range_t_1
+                    else False
+                )
+                is_fast_below_slow = (
+                    True
+                    if short_ewma_t < long_ewma_t - signal_atr_multiplier * true_range_t_1
+                    else False
+                )
 
                 if current_weight == 0.0:
                     if is_fast_above_slow:  # open long
                         current_weight = np.minimum(relative_size, weight_abs_limit)
                         stop_loss = price_t - stop_loss_atr_multiplier * true_range_t_1
                     elif is_fast_below_slow:  # open short
-                        current_weight = - np.minimum(relative_size, weight_abs_limit)
+                        current_weight = -np.minimum(relative_size, weight_abs_limit)
                         stop_loss = price_t + stop_loss_atr_multiplier * true_range_t_1
                 else:  # check current position
                     if current_weight > 0.0:
@@ -65,34 +75,38 @@ def run_american_on_instrument(price: np.ndarray,
                             current_weight = 0.0
                             stop_loss = 0.0
                         else:  # update stop loss
-                            stop_loss = np.maximum(price_t - stop_loss_atr_multiplier * true_range_t_1, stop_loss)
+                            stop_loss = np.maximum(
+                                price_t - stop_loss_atr_multiplier * true_range_t_1, stop_loss
+                            )
                     elif current_weight < 0.0:
                         # close
                         if price_t > stop_loss and not is_fast_below_slow:
                             current_weight = 0.0
                             stop_loss = 0.0
                         else:  # update stop loss
-                            stop_loss = np.minimum(price_t + stop_loss_atr_multiplier * true_range_t_1, stop_loss)
+                            stop_loss = np.minimum(
+                                price_t + stop_loss_atr_multiplier * true_range_t_1, stop_loss
+                            )
                 weights[t] = current_weight
                 stop_losses[t] = stop_loss
     return weights, stop_losses
 
 
-def run_american_system(prices: Union[pd.Series, pd.DataFrame],
-                        long_span: int = 250,
-                        short_span: int = 20,
-                        vol_span: int = 33,
-                        risk_multiplier: float = 0.01,
-                        weight_abs_limit: float = 10.0,
-                        stop_loss_atr_multiplier: float = 5.0,
-                        signal_atr_multiplier: float = 5.0,
-                        annualization_factor: float = 260,
-                        portfolio_covar_span: Optional[float] = None,
-                        portfolio_target_vol: float = 0.15,
-                        warmup_period: int = 250,
-                        volume_costs: Union[float, pd.DataFrame] = 0.0020  # assume flat across contracts
-                        ) -> BacktestOutputs:
-
+def run_american_system(
+    prices: Union[pd.Series, pd.DataFrame],
+    long_span: int = 250,
+    short_span: int = 20,
+    vol_span: int = 33,
+    risk_multiplier: float = 0.01,
+    weight_abs_limit: float = 10.0,
+    stop_loss_atr_multiplier: float = 5.0,
+    signal_atr_multiplier: float = 5.0,
+    annualization_factor: float = 260,
+    portfolio_covar_span: Optional[float] = None,
+    portfolio_target_vol: float = 0.15,
+    warmup_period: int = 250,
+    volume_costs: Union[float, pd.DataFrame] = 0.0020,  # assume flat across contracts
+) -> BacktestOutputs:
     """
     backtest of the american system on a price panel: runs the per-instrument
     crossover state machine, applies optional portfolio-level volatility
@@ -103,11 +117,15 @@ def run_american_system(prices: Union[pd.Series, pd.DataFrame],
         prices = prices.to_frame()
 
     returns_np = qis.to_returns(prices).to_numpy()
-    #1 compute volatility
-    vols = np.sqrt(annualization_factor)*compute_vol(returns=returns_np, vol_span=vol_span, is_lag1=False)
+    # 1 compute volatility
+    vols = np.sqrt(annualization_factor) * compute_vol(
+        returns=returns_np, vol_span=vol_span, is_lag1=False
+    )
     # true_range = np.power(np.pi/8.0, -5) * np.sqrt(annualization_factor) * vol
     # true_range = np.sqrt(annualization_factor) * vol
-    true_range = np.abs(prices.diff(1)).rolling(vol_span, min_periods=vol_span//2).mean().to_numpy()
+    true_range = (
+        np.abs(prices.diff(1)).rolling(vol_span, min_periods=vol_span // 2).mean().to_numpy()
+    )
     np_prices = prices.to_numpy()
     init_value = get_first_nonnan_values(np_prices)
     long_ewma = qis.ewm_recursion(a=np_prices, span=long_span, init_value=init_value)
@@ -115,31 +133,38 @@ def run_american_system(prices: Union[pd.Series, pd.DataFrame],
 
     weights = np.zeros_like(np_prices)
     for idx, column in enumerate(prices.columns):
-        weights[:, idx], stop_loss = run_american_on_instrument(price=np_prices[:, idx],
-                                                                long_ewma=long_ewma[:, idx],
-                                                                short_ewma=short_ewma[:, idx],
-                                                                true_range=true_range[:, idx],
-                                                                weight_abs_limit=weight_abs_limit,
-                                                                risk_multiplier=risk_multiplier,
-                                                                stop_loss_atr_multiplier=stop_loss_atr_multiplier,
-                                                                signal_atr_multiplier=signal_atr_multiplier,
-                                                                warmup_period=warmup_period)
+        weights[:, idx], stop_loss = run_american_on_instrument(
+            price=np_prices[:, idx],
+            long_ewma=long_ewma[:, idx],
+            short_ewma=short_ewma[:, idx],
+            true_range=true_range[:, idx],
+            weight_abs_limit=weight_abs_limit,
+            risk_multiplier=risk_multiplier,
+            stop_loss_atr_multiplier=stop_loss_atr_multiplier,
+            signal_atr_multiplier=signal_atr_multiplier,
+            warmup_period=warmup_period,
+        )
 
     if portfolio_covar_span is not None:
-        portfolio_var = qis.compute_portfolio_var_np(returns=returns_np, weights=weights, span=portfolio_covar_span)
-        reciprocal_portfolio_var = np.reciprocal(annualization_factor*portfolio_var, where=portfolio_var > 0.0)
+        portfolio_var = qis.compute_portfolio_var_np(
+            returns=returns_np, weights=weights, span=portfolio_covar_span
+        )
+        reciprocal_portfolio_var = np.reciprocal(
+            annualization_factor * portfolio_var, where=portfolio_var > 0.0
+        )
         leverage = portfolio_target_vol * np.sqrt(reciprocal_portfolio_var)
         weights = weights * qis.np_array_to_df_columns(a=leverage, ncols=len(prices.columns))
 
     if isinstance(volume_costs, float):
-        volume_costs = volume_costs*np.ones_like(weights)
+        volume_costs = volume_costs * np.ones_like(weights)
     elif isinstance(volume_costs, pd.DataFrame):
         volume_costs = volume_costs.to_numpy()
     else:
         raise NotImplementedError(f"{type(volume_costs)}")
 
-    backtest_outputs = BacktestOutputs(*compute_pnl(weights=weights, returns=returns_np, volume_costs=volume_costs,
-                                                    vols=vols))
+    backtest_outputs = BacktestOutputs(
+        *compute_pnl(weights=weights, returns=returns_np, volume_costs=volume_costs, vols=vols)
+    )
 
     weights = pd.DataFrame(weights, index=prices.index, columns=prices.columns)
     backtest_outputs.np_arrays_to_frames(weights=weights, name='American')

--- a/src/trendfollowing/systems/backtest_utils.py
+++ b/src/trendfollowing/systems/backtest_utils.py
@@ -5,6 +5,7 @@ backtest outputs
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 import numpy as np
 import pandas as pd
 import qis as qis
@@ -19,6 +20,7 @@ class BacktestOutputs:
     """
     pandas wrapper for outputs from compute_pnl
     """
+
     portfolio_pnl: Union[np.ndarray, pd.Series]
     portfolio_pnl_net: Union[np.ndarray, pd.Series]
     portfolio_turnover: Union[np.ndarray, pd.Series]
@@ -29,7 +31,9 @@ class BacktestOutputs:
     weights: Union[np.ndarray, pd.DataFrame] = None
     signals: Union[np.ndarray, pd.DataFrame] = None
 
-    def np_arrays_to_frames(self, weights: pd.DataFrame, signals: np.ndarray = None, name: str = 'European') -> None:
+    def np_arrays_to_frames(
+        self, weights: pd.DataFrame, signals: np.ndarray = None, name: str = 'European'
+    ) -> None:
         """
         map numpy arrays to dataframe using weights index and columns
         """
@@ -37,20 +41,24 @@ class BacktestOutputs:
         self.portfolio_pnl = pd.Series(self.portfolio_pnl, index=weights.index, name=name)
         self.portfolio_pnl_net = pd.Series(self.portfolio_pnl_net, index=weights.index, name=name)
         self.portfolio_turnover = pd.Series(self.portfolio_turnover, index=weights.index, name=name)
-        self.portfolio_vol_turnover = pd.Series(self.portfolio_vol_turnover, index=weights.index, name=name)
+        self.portfolio_vol_turnover = pd.Series(
+            self.portfolio_vol_turnover, index=weights.index, name=name
+        )
         self.portfolio_cost = pd.Series(self.portfolio_cost, index=weights.index, name=name)
-        self.instrument_pnl = pd.DataFrame(self.instrument_pnl, index=weights.index, columns=weights.columns)
-        self.instrument_pnl_net = pd.DataFrame(self.instrument_pnl_net, index=weights.index, columns=weights.columns)
+        self.instrument_pnl = pd.DataFrame(
+            self.instrument_pnl, index=weights.index, columns=weights.columns
+        )
+        self.instrument_pnl_net = pd.DataFrame(
+            self.instrument_pnl_net, index=weights.index, columns=weights.columns
+        )
         if signals is not None:
             self.signals = pd.DataFrame(signals, index=weights.index, columns=weights.columns)
 
 
 @njit
-def compute_pnl(weights: np.ndarray,
-                returns: np.ndarray,
-                volume_costs: np.ndarray,
-                vols: np.ndarray
-                ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def compute_pnl(
+    weights: np.ndarray, returns: np.ndarray, volume_costs: np.ndarray, vols: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     compute p&l of weights
     weights, returns, volume_costs must have same dimension
@@ -59,9 +67,9 @@ def compute_pnl(weights: np.ndarray,
         instrument_pnl = weights[:-1] * returns[1:]
         instrument_pnl = np.append([np.nan], instrument_pnl)  # add zero row
 
-        abs_weight_change = np.abs(weights[1:]-weights[:-1])
+        abs_weight_change = np.abs(weights[1:] - weights[:-1])
         abs_weight_change = np.append([np.nan], abs_weight_change)  # add zero row
-        vol_abs_weight_change = abs_weight_change*vols
+        vol_abs_weight_change = abs_weight_change * vols
 
         instrument_costs = abs_weight_change * volume_costs
         instrument_pnl_net = instrument_pnl - instrument_costs
@@ -73,11 +81,15 @@ def compute_pnl(weights: np.ndarray,
         portfolio_cost = portfolio_turnover * volume_costs
     else:
         instrument_pnl = weights[:-1, :] * returns[1:, :]  # add zero row
-        instrument_pnl = np.concatenate((np.nan*np.ones((1, weights.shape[1])), instrument_pnl), axis=0)
+        instrument_pnl = np.concatenate(
+            (np.nan * np.ones((1, weights.shape[1])), instrument_pnl), axis=0
+        )
 
         abs_weight_change = np.abs(weights[1:, :] - weights[:-1, :])
-        abs_weight_change = np.concatenate((np.nan*np.ones((1, weights.shape[1])), abs_weight_change), axis=0)
-        vol_abs_weight_change = abs_weight_change*vols
+        abs_weight_change = np.concatenate(
+            (np.nan * np.ones((1, weights.shape[1])), abs_weight_change), axis=0
+        )
+        vol_abs_weight_change = abs_weight_change * vols
 
         instrument_costs = abs_weight_change * volume_costs
         instrument_pnl_net = instrument_pnl - instrument_costs
@@ -90,23 +102,26 @@ def compute_pnl(weights: np.ndarray,
         portfolio_cost = np_nansum(instrument_costs, axis=1, keep_dim=False)[0]
 
     # pnl = np.cumsum(pnl_paths)
-    portfolio_pnl = np.cumprod(1.0+portfolio_pnl)
-    portfolio_pnl_net = np.cumprod(1.0+portfolio_pnl_net)
+    portfolio_pnl = np.cumprod(1.0 + portfolio_pnl)
+    portfolio_pnl_net = np.cumprod(1.0 + portfolio_pnl_net)
 
-    return (portfolio_pnl, portfolio_pnl_net,
-            portfolio_turnover, portfolio_vol_turnover, portfolio_cost,
-            instrument_pnl, instrument_pnl_net)
+    return (
+        portfolio_pnl,
+        portfolio_pnl_net,
+        portfolio_turnover,
+        portfolio_vol_turnover,
+        portfolio_cost,
+        instrument_pnl,
+        instrument_pnl_net,
+    )
 
 
 @njit
-def compute_vol(returns: np.ndarray,
-                vol_span: float = 31.0,
-                is_lag1: bool = True
-                ) -> np.ndarray:
+def compute_vol(returns: np.ndarray, vol_span: float = 31.0, is_lag1: bool = True) -> np.ndarray:
     """
     compute return_t / ewma_vol_{t-1}
     """
-    ewm_lambda = 1.0 - 2.0/(vol_span + 1.0)
+    ewm_lambda = 1.0 - 2.0 / (vol_span + 1.0)
     if returns.ndim == 1:
         init_value = np.nanvar(returns)
     else:
@@ -126,9 +141,7 @@ def compute_vol(returns: np.ndarray,
 
 
 @njit
-def compute_vol_norm_returns(returns: np.ndarray,
-                             vol_span: float = 31.0
-                             ) -> np.ndarray:
+def compute_vol_norm_returns(returns: np.ndarray, vol_span: float = 31.0) -> np.ndarray:
     """
     compute return_t / ewma_vol_{t-1}
     """
@@ -138,32 +151,37 @@ def compute_vol_norm_returns(returns: np.ndarray,
 
 
 @njit
-def compute_vol_target_weight(returns: np.ndarray,
-                              vol_span: int = 33,
-                              vol_target: float = 0.15,
-                              annualization_factor: float = 260
-                              ) -> Tuple[np.ndarray, np.ndarray]:
+def compute_vol_target_weight(
+    returns: np.ndarray,
+    vol_span: int = 33,
+    vol_target: float = 0.15,
+    annualization_factor: float = 260,
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     compute pnl of weight = (vol_target /  vol_{t}) * signal t
     """
-    vols = np.sqrt(annualization_factor) * compute_vol(returns=returns, vol_span=vol_span, is_lag1=False)
-    weights = (vol_target/vols)
+    vols = np.sqrt(annualization_factor) * compute_vol(
+        returns=returns, vol_span=vol_span, is_lag1=False
+    )
+    weights = vol_target / vols
     return weights, vols
 
 
-#@njit
-def compute_path_stats(pnl_paths: np.ndarray,
-                       annualization_factor: float = 260.0
-                       ) -> Tuple[np.ndarray, ...]:
+# @njit
+def compute_path_stats(
+    pnl_paths: np.ndarray, annualization_factor: float = 260.0
+) -> Tuple[np.ndarray, ...]:
     """
     compute cumulative pnl
     """
     pnl_paths0 = pnl_paths.copy()
-    pnl_paths0[np.isnan(pnl_paths)] = 0.0 # fill nans
+    pnl_paths0[np.isnan(pnl_paths)] = 0.0  # fill nans
     cum_pnl = np_cumsum(pnl_paths0, axis=0)
     total_pnl = cum_pnl[-1, :]
-    nonnan_years = np.sum(~np.isnan(pnl_paths), axis=0) /annualization_factor
+    nonnan_years = np.sum(~np.isnan(pnl_paths), axis=0) / annualization_factor
     pnl_an = total_pnl / nonnan_years
-    vol_an = np.sqrt(annualization_factor)*np_nanstd(pnl_paths, axis=0).flatten()  # vol of original paths with nans
+    vol_an = (
+        np.sqrt(annualization_factor) * np_nanstd(pnl_paths, axis=0).flatten()
+    )  # vol of original paths with nans
     sharpe = pnl_an / vol_an
     return total_pnl, pnl_an, vol_an, sharpe

--- a/src/trendfollowing/systems/european.py
+++ b/src/trendfollowing/systems/european.py
@@ -8,23 +8,29 @@ ratio, and the skewness of aggregated returns
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 import numpy as np
 import pandas as pd
 import qis as qis
 from qis.utils.np_ops import set_nans_for_warmup_period
 from numba import njit
 from typing import Optional, Union, Tuple
-from trendfollowing.systems.backtest_utils import compute_pnl, compute_vol_norm_returns, BacktestOutputs, \
-    compute_vol_target_weight
+from trendfollowing.systems.backtest_utils import (
+    compute_pnl,
+    compute_vol_norm_returns,
+    BacktestOutputs,
+    compute_vol_target_weight,
+)
 
 
 @njit
-def compute_tf_signal(returns: np.ndarray,
-                      vol_norm_returns: np.ndarray = None,
-                      long_span: float = 33,
-                      short_span: Optional[int] = None,
-                      vol_span: float = 33
-                      ) -> np.ndarray:
+def compute_tf_signal(
+    returns: np.ndarray,
+    vol_norm_returns: np.ndarray = None,
+    long_span: float = 33,
+    short_span: Optional[int] = None,
+    vol_span: float = 33,
+) -> np.ndarray:
     """
     ewma signal of volatility-normalized returns: the single filter for
     short_span None and the long-short raw-filter difference otherwise
@@ -35,81 +41,88 @@ def compute_tf_signal(returns: np.ndarray,
         init_value = 0.0
     else:
         init_value = np.zeros(vol_norm_returns.shape[1])
-    signal = qis.compute_ewm_long_short(a=vol_norm_returns,
-                                        long_span=long_span,
-                                        short_span=short_span,
-                                        init_value=init_value)
+    signal = qis.compute_ewm_long_short(
+        a=vol_norm_returns, long_span=long_span, short_span=short_span, init_value=init_value
+    )
     # signal[np.isnan(vol_norm_returns)] = np.nan  # make nans - necessary when using init_value
-    signal = np.where(np.isnan(vol_norm_returns) == False, signal, np.nan)
+    signal = np.where(~np.isnan(vol_norm_returns), signal, np.nan)
     return signal
 
 
 @njit
-def compute_tf_signal_weight(returns: np.ndarray,
-                             long_span: float = 31.0,
-                             short_span: Optional[float] = None,
-                             vol_span: int = 33,
-                             vol_target: float = 0.30,
-                             annualization_factor: float = 260,
-                             signal_cap: Optional[float] = None
-                             ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def compute_tf_signal_weight(
+    returns: np.ndarray,
+    long_span: float = 31.0,
+    short_span: Optional[float] = None,
+    vol_span: int = 33,
+    vol_target: float = 0.30,
+    annualization_factor: float = 260,
+    signal_cap: Optional[float] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     signal and per-instrument weights of the european system:
     weight_t = (vol_target / vol_t) * signal_t, with an optional cap on the signal
     """
-    signal = compute_tf_signal(returns=returns,
-                               long_span=long_span,
-                               short_span=short_span,
-                               vol_span=vol_span)
+    signal = compute_tf_signal(
+        returns=returns, long_span=long_span, short_span=short_span, vol_span=vol_span
+    )
     if signal_cap is not None:
         signal = np.clip(signal, -signal_cap, signal_cap)
-    vol_target_weight, vols = compute_vol_target_weight(returns=returns, vol_span=vol_span, vol_target=vol_target, annualization_factor=annualization_factor)
+    vol_target_weight, vols = compute_vol_target_weight(
+        returns=returns,
+        vol_span=vol_span,
+        vol_target=vol_target,
+        annualization_factor=annualization_factor,
+    )
     weights = vol_target_weight * signal
     return weights, signal, vols
 
 
-#@njit  # cannot work
-def compute_tf_strat_pnl(returns: np.ndarray,
-                         long_span: float = 31.0,
-                         short_span: Optional[float] = None,
-                         vol_span: int = 33,
-                         vol_target: float = 0.15,
-                         annualization_factor: float = 260
-                         ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+# @njit  # cannot work
+def compute_tf_strat_pnl(
+    returns: np.ndarray,
+    long_span: float = 31.0,
+    short_span: Optional[float] = None,
+    vol_span: int = 33,
+    vol_target: float = 0.15,
+    annualization_factor: float = 260,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     compute pnl of weight = (vol_target /  vol_{t}) * signal t
     """
-    weights, signals, vols = compute_tf_signal_weight(returns=returns,
-                                                      long_span=long_span,
-                                                      short_span=short_span,
-                                                      vol_span=vol_span,
-                                                      vol_target=vol_target,
-                                                      annualization_factor=annualization_factor)
+    weights, signals, vols = compute_tf_signal_weight(
+        returns=returns,
+        long_span=long_span,
+        short_span=short_span,
+        vol_span=vol_span,
+        vol_target=vol_target,
+        annualization_factor=annualization_factor,
+    )
     # add zero row so that dim[0] equals to dim[0] of returns
     if weights.ndim == 1:
         pnl = weights[:-1] * returns[1:]
         pnl = np.append([np.nan], pnl)  # add nan row
     else:
         pnl = weights[:-1, :] * returns[1:, :]
-        pnl = np.concatenate((np.nan*np.ones((1, weights.shape[1])), pnl), axis=0)
+        pnl = np.concatenate((np.nan * np.ones((1, weights.shape[1])), pnl), axis=0)
 
     return pnl, weights, vols
 
 
-def run_european_tf_system(prices: pd.DataFrame,
-                           long_span: int = 31,
-                           short_span: Optional[int] = None,
-                           vol_span: int = 33,
-                           vol_target: float = 0.3,
-                           portfolio_covar_span: Optional[int] = None,
-                           portfolio_target_vol: float = 0.15,
-                           annualization_factor: float = 260.0,
-                           volume_costs: Union[float, pd.DataFrame] = 0.0020,  # assume flat across contracts
-                           warmup_period: Optional[int] = 250,
-                           signal_cap: Optional[float] = 3.0,
-                           weight_cap: Optional[float] = 5.0
-                           ) -> BacktestOutputs:
-
+def run_european_tf_system(
+    prices: pd.DataFrame,
+    long_span: int = 31,
+    short_span: Optional[int] = None,
+    vol_span: int = 33,
+    vol_target: float = 0.3,
+    portfolio_covar_span: Optional[int] = None,
+    portfolio_target_vol: float = 0.15,
+    annualization_factor: float = 260.0,
+    volume_costs: Union[float, pd.DataFrame] = 0.0020,  # assume flat across contracts
+    warmup_period: Optional[int] = 250,
+    signal_cap: Optional[float] = 3.0,
+    weight_cap: Optional[float] = 5.0,
+) -> BacktestOutputs:
     """
     backtest of the european system on a price panel: builds the signal and
     volatility-target weights, applies optional portfolio-level volatility
@@ -117,21 +130,29 @@ def run_european_tf_system(prices: pd.DataFrame,
     turnover and costs
     """
     returns_np = qis.to_returns(prices, is_log_returns=True, is_first_zero=False).to_numpy()
-    weights, signals, vols = compute_tf_signal_weight(returns=returns_np,
-                                                      long_span=long_span,
-                                                      short_span=short_span,
-                                                      vol_span=vol_span,
-                                                      vol_target=vol_target,
-                                                      signal_cap=signal_cap)
+    weights, signals, vols = compute_tf_signal_weight(
+        returns=returns_np,
+        long_span=long_span,
+        short_span=short_span,
+        vol_span=vol_span,
+        vol_target=vol_target,
+        signal_cap=signal_cap,
+    )
     if weight_cap is not None:
         weights = np.clip(weights, -weight_cap, weight_cap)
 
     if portfolio_covar_span is not None:
-        portfolio_var = qis.compute_portfolio_var_np(returns=returns_np, weights=weights, span=portfolio_covar_span)
+        portfolio_var = qis.compute_portfolio_var_np(
+            returns=returns_np, weights=weights, span=portfolio_covar_span
+        )
         # np.reciprocal with where= but no out= leaves the masked cells uninitialised (undefined
         # behaviour); pass an initialised zero out so non-positive-variance days get zero leverage
         reciprocal_portfolio_var = np.zeros_like(portfolio_var)
-        np.reciprocal(annualization_factor*portfolio_var, where=portfolio_var > 0.0, out=reciprocal_portfolio_var)
+        np.reciprocal(
+            annualization_factor * portfolio_var,
+            where=portfolio_var > 0.0,
+            out=reciprocal_portfolio_var,
+        )
         leverage = portfolio_target_vol * np.sqrt(reciprocal_portfolio_var)
         weights = weights * qis.np_array_to_df_columns(a=leverage, ncols=len(prices.columns))
 
@@ -139,14 +160,15 @@ def run_european_tf_system(prices: pd.DataFrame,
         weights = set_nans_for_warmup_period(a=weights, warmup_period=warmup_period)
 
     if isinstance(volume_costs, float):
-        volume_costs = volume_costs*np.ones_like(weights)
+        volume_costs = volume_costs * np.ones_like(weights)
     elif isinstance(volume_costs, pd.DataFrame):
         volume_costs = volume_costs.to_numpy()
     else:
         raise NotImplementedError(f"{type(volume_costs)}")
 
-    backtest_outputs = BacktestOutputs(*compute_pnl(weights=weights, returns=returns_np,
-                                                    volume_costs=volume_costs, vols=vols))
+    backtest_outputs = BacktestOutputs(
+        *compute_pnl(weights=weights, returns=returns_np, volume_costs=volume_costs, vols=vols)
+    )
     weights = pd.DataFrame(weights, index=prices.index, columns=prices.columns)
     backtest_outputs.np_arrays_to_frames(weights=weights, signals=signals, name='European')
 

--- a/src/trendfollowing/systems/tsmom.py
+++ b/src/trendfollowing/systems/tsmom.py
@@ -5,25 +5,29 @@ generalizing moskowitz-ooi-pedersen momentum, with volatility-targeted sizing
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 import numpy as np
 import pandas as pd
 import qis as qis
 from qis.utils.df_freq import df_resample_at_int_index
 from qis.utils.np_ops import set_nans_for_warmup_period
 from typing import Optional, Union, Tuple
-from trendfollowing.systems.backtest_utils import (compute_pnl,
-                                             compute_vol_norm_returns,
-                                             BacktestOutputs,
-                                             compute_vol_target_weight)
+from trendfollowing.systems.backtest_utils import (
+    compute_pnl,
+    compute_vol_norm_returns,
+    BacktestOutputs,
+    compute_vol_target_weight,
+)
 
 
-def compute_tsmom_signal_weight(returns: pd.DataFrame,
-                                num_ra_returns: int = 22,
-                                num_periods: int = 12,
-                                vol_span: int = 33,
-                                vol_target: float = 0.15,
-                                annualization_factor: float = 260
-                                ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def compute_tsmom_signal_weight(
+    returns: pd.DataFrame,
+    num_ra_returns: int = 22,
+    num_periods: int = 12,
+    vol_span: int = 33,
+    vol_target: float = 0.15,
+    annualization_factor: float = 260,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     tsmom signal and weights: the signs of period returns averaged over
     num_periods with sqrt normalization, scaled by the volatility-target
@@ -31,13 +35,23 @@ def compute_tsmom_signal_weight(returns: pd.DataFrame,
     """
     vol_norm_returns = compute_vol_norm_returns(returns=returns.to_numpy(), vol_span=vol_span)
     vol_norm_returns = pd.DataFrame(vol_norm_returns, index=returns.index, columns=returns.columns)
-    signals = np.sqrt(num_ra_returns)*df_resample_at_int_index(df=np.sign(vol_norm_returns), func=np.nanmean, sample_size=num_ra_returns)
-    signals = np.sqrt(num_periods)*signals.rolling(num_periods).mean()
-    vol_target_weight, vols = compute_vol_target_weight(returns=returns.to_numpy(), vol_span=vol_span,
-                                                        vol_target=vol_target, annualization_factor=annualization_factor)
+    signals = np.sqrt(num_ra_returns) * df_resample_at_int_index(
+        df=np.sign(vol_norm_returns), func=np.nanmean, sample_size=num_ra_returns
+    )
+    signals = np.sqrt(num_periods) * signals.rolling(num_periods).mean()
+    vol_target_weight, vols = compute_vol_target_weight(
+        returns=returns.to_numpy(),
+        vol_span=vol_span,
+        vol_target=vol_target,
+        annualization_factor=annualization_factor,
+    )
     # need to reindex at singal index
-    vol_target_weight = pd.DataFrame(vol_target_weight, index=returns.index, columns=returns.columns).reindex(index=signals.index, method='ffill')
-    vols = pd.DataFrame(vols, index=returns.index, columns=returns.columns).reindex(index=signals.index, method='ffill')
+    vol_target_weight = pd.DataFrame(
+        vol_target_weight, index=returns.index, columns=returns.columns
+    ).reindex(index=signals.index, method='ffill')
+    vols = pd.DataFrame(vols, index=returns.index, columns=returns.columns).reindex(
+        index=signals.index, method='ffill'
+    )
 
     weights = vol_target_weight.multiply(signals)
 
@@ -48,35 +62,39 @@ def compute_tsmom_signal_weight(returns: pd.DataFrame,
     return weights, signals, vols
 
 
-def run_tsmom_system(prices: pd.DataFrame,
-                     num_ra_returns: int = 10,
-                     num_periods: int = 10,
-                     vol_span: int = 33,
-                     vol_target: float = 0.00435,
-                     portfolio_covar_span: Optional[int] = None,
-                     portfolio_target_vol: float = 0.15,
-                     annualization_factor: float = 260.0,
-                     volume_costs: Union[float, pd.DataFrame] = 0.0020,  # assume flat across contracts
-                     warmup_period: Optional[int] = 250 # monthly basis
-                     ) -> BacktestOutputs:
-
+def run_tsmom_system(
+    prices: pd.DataFrame,
+    num_ra_returns: int = 10,
+    num_periods: int = 10,
+    vol_span: int = 33,
+    vol_target: float = 0.00435,
+    portfolio_covar_span: Optional[int] = None,
+    portfolio_target_vol: float = 0.15,
+    annualization_factor: float = 260.0,
+    volume_costs: Union[float, pd.DataFrame] = 0.0020,  # assume flat across contracts
+    warmup_period: Optional[int] = 250,  # monthly basis
+) -> BacktestOutputs:
     """
     backtest of the tsmom system on a price panel with optional portfolio-level
     volatility targeting, warmup masking, and volume-based costs
     """
     returns = qis.to_returns(prices, is_first_zero=False)
-    weights, signal, vols = compute_tsmom_signal_weight(returns=returns,
-                                                num_ra_returns=num_ra_returns,
-                                                num_periods=num_periods,
-                                                vol_span=vol_span,
-                                                vol_target=vol_target,
-                                                annualization_factor=annualization_factor)
+    weights, signal, vols = compute_tsmom_signal_weight(
+        returns=returns,
+        num_ra_returns=num_ra_returns,
+        num_periods=num_periods,
+        vol_span=vol_span,
+        vol_target=vol_target,
+        annualization_factor=annualization_factor,
+    )
 
     if portfolio_covar_span is not None:
-        portfolio_var = qis.compute_portfolio_var_np(returns=returns.to_numpy(),
-                                                     weights=weights.to_numpy(),
-                                                     span=portfolio_covar_span)
-        reciprocal_portfolio_var = np.reciprocal(annualization_factor*portfolio_var, where=portfolio_var > 0.0)
+        portfolio_var = qis.compute_portfolio_var_np(
+            returns=returns.to_numpy(), weights=weights.to_numpy(), span=portfolio_covar_span
+        )
+        reciprocal_portfolio_var = np.reciprocal(
+            annualization_factor * portfolio_var, where=portfolio_var > 0.0
+        )
         leverage = portfolio_target_vol * np.sqrt(reciprocal_portfolio_var)
         weights = weights * qis.np_array_to_df_columns(a=leverage, ncols=len(prices.columns))
 
@@ -84,15 +102,21 @@ def run_tsmom_system(prices: pd.DataFrame,
         weights = set_nans_for_warmup_period(a=weights, warmup_period=warmup_period)
 
     if isinstance(volume_costs, float):
-        volume_costs = volume_costs*np.ones_like(weights)
+        volume_costs = volume_costs * np.ones_like(weights)
     elif isinstance(volume_costs, pd.DataFrame):
         volume_costs = volume_costs.reindex(index=weights.index, method='ffill')
         volume_costs = volume_costs.to_numpy()
     else:
         raise NotImplementedError(f"{type(volume_costs)}")
 
-    backtest_outputs = BacktestOutputs(*compute_pnl(weights=weights.to_numpy(), returns=returns.to_numpy(),
-                                                    volume_costs=volume_costs, vols=vols.to_numpy()))
+    backtest_outputs = BacktestOutputs(
+        *compute_pnl(
+            weights=weights.to_numpy(),
+            returns=returns.to_numpy(),
+            volume_costs=volume_costs,
+            vols=vols.to_numpy(),
+        )
+    )
     weights = pd.DataFrame(weights, index=prices.index, columns=prices.columns)
     backtest_outputs.np_arrays_to_frames(weights=weights, name='TSMOM')
 

--- a/src/trendfollowing/universe.py
+++ b/src/trendfollowing/universe.py
@@ -7,6 +7,7 @@ set TF_RESOURCE_PATH to override the packaged data with a local folder
 reference: Sepp, A. and Lucic, V., The Science and Practice of Trend-Following Systems,
 https://ssrn.com/abstract=3167787
 """
+
 import os
 import pandas as pd
 import numpy as np
@@ -18,16 +19,41 @@ from qis import TimePeriod
 # Kept for compatibility with older research scripts. Public loaders resolve the
 # path at call time so a TF_RESOURCE_PATH override never depends on import order.
 from trendfollowing.local_path import get_universe_data_path
+
 LOCAL_PATH = get_universe_data_path()
 
 
-# one-way volume-based transaction costs by asset group and period, following exhibit b1 in hurst et al (2017)
-COST_STRUCTURE = {TimePeriod(end='31Dec1992'): {'Equities': 0.0034, 'Bonds': 0.0006, 'STIR': 0.0006, 'FX': 0.0018,
-                                                'Energy': 0.0058, 'Metals': 0.0058, 'Agriculture': 0.0058},
-                  TimePeriod(end='31Dec2002'): {'Equities': 0.0011, 'Bonds': 0.0002, 'STIR': 0.0002, 'FX': 0.0006,
-                                                'Energy': 0.0019, 'Metals': 0.0019, 'Agriculture': 0.0019},
-                  TimePeriod(end='31Dec2029'): {'Equities': 0.0006, 'Bonds': 0.0001, 'STIR': 0.0001, 'FX': 0.0003,
-                                                'Energy': 0.0010, 'Metals': 0.0010, 'Agriculture': 0.0010}}
+# One-way volume-based transaction costs by asset group and period, following
+# exhibit B1 in Hurst et al. (2017).
+COST_STRUCTURE = {
+    TimePeriod(end='31Dec1992'): {
+        'Equities': 0.0034,
+        'Bonds': 0.0006,
+        'STIR': 0.0006,
+        'FX': 0.0018,
+        'Energy': 0.0058,
+        'Metals': 0.0058,
+        'Agriculture': 0.0058,
+    },
+    TimePeriod(end='31Dec2002'): {
+        'Equities': 0.0011,
+        'Bonds': 0.0002,
+        'STIR': 0.0002,
+        'FX': 0.0006,
+        'Energy': 0.0019,
+        'Metals': 0.0019,
+        'Agriculture': 0.0019,
+    },
+    TimePeriod(end='31Dec2029'): {
+        'Equities': 0.0006,
+        'Bonds': 0.0001,
+        'STIR': 0.0001,
+        'FX': 0.0003,
+        'Energy': 0.0010,
+        'Metals': 0.0010,
+        'Agriculture': 0.0010,
+    },
+}
 
 
 def get_costs(prices: pd.DataFrame, group_data: pd.Series) -> pd.DataFrame:
@@ -42,7 +68,9 @@ def get_costs(prices: pd.DataFrame, group_data: pd.Series) -> pd.DataFrame:
         end_date = date.end
         instrument_costs = group_data.map(ac_cost)
         n_index = len(costs.loc[start_date:end_date, :].index)
-        costs.loc[start_date:end_date, :] = qis.np_array_to_df_index(a=instrument_costs.to_numpy(), n_index=n_index)
+        costs.loc[start_date:end_date, :] = qis.np_array_to_df_index(
+            a=instrument_costs.to_numpy(), n_index=n_index
+        )
         start_date = end_date
     return costs
 
@@ -63,48 +91,60 @@ def generate_data() -> None:
     from futures_strats.data.universes.futures.bbg_futures import Universes
     from bbg_fetch import fetch_field_timeseries_per_tickers
 
-    strategy_universe = Universes.BBG_FUTURES_INVESTABLE.load_universe_data(
-        local_path=local_path
-    )
+    strategy_universe = Universes.BBG_FUTURES_INVESTABLE.load_universe_data(local_path=local_path)
     prices = strategy_universe.get_prices()
     usd_returns = strategy_universe.get_usd_returns()
 
     group_data = strategy_universe.get_ac_data(to_value=True)
     names = strategy_universe.get_instrument_names()
-    descriptive_df = pd.concat([group_data.rename('group_data'), names.rename('names')],
-                               axis=1, sort=False)
+    descriptive_df = pd.concat(
+        [group_data.rename('group_data'), names.rename('names')], axis=1, sort=False
+    )
     volume_costs = get_costs(prices=prices, group_data=group_data)
 
-    es_ty = qis.backtest_model_portfolio(prices=prices[['ES1 Index', 'TY1 Comdty']],
-                                                    weights=np.array([0.6, 0.4]),
-                                                    rebalancing_freq='QE').get_portfolio_nav().to_frame('60/40 Equity/Bond')
+    es_ty = (
+        qis.backtest_model_portfolio(
+            prices=prices[['ES1 Index', 'TY1 Comdty']],
+            weights=np.array([0.6, 0.4]),
+            rebalancing_freq='QE',
+        )
+        .get_portfolio_nav()
+        .to_frame('60/40 Equity/Bond')
+    )
 
-    benchmark_prices = fetch_field_timeseries_per_tickers(tickers={'NEIXCTAT Index': 'SG Trend'}, freq='B', field='PX_LAST').ffill()
+    benchmark_prices = fetch_field_timeseries_per_tickers(
+        tickers={'NEIXCTAT Index': 'SG Trend'}, freq='B', field='PX_LAST'
+    ).ffill()
     benchmark_prices = pd.concat([es_ty, benchmark_prices], axis=1, sort=True)
 
-    qis.save_df_dict_to_csv(datasets=dict(prices=prices,
-                                          usd_returns=usd_returns,
-                                          volume_costs=volume_costs,
-                                          benchmark_prices=benchmark_prices,
-                                          descriptive_df=descriptive_df,
-                                          credit_df=credit_df),
-                            file_name='tf_system_data',
-                            local_path=local_path)
+    qis.save_df_dict_to_csv(
+        datasets=dict(
+            prices=prices,
+            usd_returns=usd_returns,
+            volume_costs=volume_costs,
+            benchmark_prices=benchmark_prices,
+            descriptive_df=descriptive_df,
+        ),
+        file_name='tf_system_data',
+        local_path=local_path,
+    )
 
 
-#@qis.timer
-def load_data(time_period: TimePeriod = None,
-              tickers: List[str] = None
-              ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, List[str]]:
-
+# @qis.timer
+def load_data(
+    time_period: TimePeriod = None, tickers: List[str] = None
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, List[str]]:
     """
     load the packaged futures dataset: prices, volume costs, benchmark prices,
     descriptive metadata, and the asset-group order, optionally restricted to a
     time period and a ticker list
     """
     local_path = get_universe_data_path()
-    dfs = qis.load_df_dict_from_csv(dataset_keys=['prices', 'volume_costs', 'benchmark_prices', 'descriptive_df'],
-                                    file_name='tf_system_data', local_path=local_path)
+    dfs = qis.load_df_dict_from_csv(
+        dataset_keys=['prices', 'volume_costs', 'benchmark_prices', 'descriptive_df'],
+        file_name='tf_system_data',
+        local_path=local_path,
+    )
     prices = dfs['prices']
     volume_costs = dfs['volume_costs']
     benchmark_prices = dfs['benchmark_prices']

--- a/tests/test_sharpe.py
+++ b/tests/test_sharpe.py
@@ -1,14 +1,23 @@
 """
-tests for tf_model.paper.sharpe: variance preservation, closed forms, consistency with expected-return formulas
+tests for tf_model.paper.sharpe: variance preservation, closed forms, and
+consistency with expected-return formulas
 """
+
 # packages
 import numpy as np
+
 # project
 from trendfollowing.analytics.filters import span_to_nu
 from trendfollowing.analytics.autocorrelation import population_acf, compute_psi_nu
-from trendfollowing.analytics.sharpe import (compute_signal_moments, compute_annualised_sharpe,
-                                             sharpe_white_noise, sharpe_white_noise_approx,
-                                             sharpe_ar1, sharpe_ar1_approx, expected_annual_return)
+from trendfollowing.analytics.sharpe import (
+    compute_signal_moments,
+    compute_annualised_sharpe,
+    sharpe_white_noise,
+    sharpe_white_noise_approx,
+    sharpe_ar1,
+    sharpe_ar1_approx,
+    expected_annual_return,
+)
 from trendfollowing.analytics.expected_return import expected_pnl_white_noise, expected_pnl_ar1
 
 
@@ -43,12 +52,16 @@ def test_sowell_acf_finite_and_normalised():
 def test_expected_return_matches_formulas():
     rho_wn = population_acf(n_lags=5)
     for span in [21.0, 250.0]:
-        mine = expected_annual_return(rho=rho_wn, long_span=span, sr_underlying=0.5, vol_target=0.15)
+        mine = expected_annual_return(
+            rho=rho_wn, long_span=span, sr_underlying=0.5, vol_target=0.15
+        )
         his = expected_pnl_white_noise(long_span=span, mean=0.5, vol_target=0.15)
         assert np.isclose(mine, his)
     rho_ar = population_acf(n_lags=3000, phi=0.05)
     for span in [21.0, 250.0]:
-        mine = expected_annual_return(rho=rho_ar, long_span=span, sr_underlying=0.0, vol_target=0.15)
+        mine = expected_annual_return(
+            rho=rho_ar, long_span=span, sr_underlying=0.0, vol_target=0.15
+        )
         his = expected_pnl_ar1(phi=0.05, long_span=span, mean=0.0, vol_target=0.15)
         assert np.isclose(mine, his)
 
@@ -61,6 +74,11 @@ def test_sharpe_independent_of_variance_scale_zero_drift():
 
 
 def test_approximations_close_to_exact():
-    assert np.isclose(sharpe_ar1(phi=0.05, long_span=21.0), sharpe_ar1_approx(phi=0.05, long_span=21.0), atol=5e-3)
-    assert np.isclose(sharpe_white_noise(long_span=21.0, sr_underlying=0.25),
-                      sharpe_white_noise_approx(long_span=21.0, sr_underlying=0.25), atol=5e-3)
+    assert np.isclose(
+        sharpe_ar1(phi=0.05, long_span=21.0), sharpe_ar1_approx(phi=0.05, long_span=21.0), atol=5e-3
+    )
+    assert np.isclose(
+        sharpe_white_noise(long_span=21.0, sr_underlying=0.25),
+        sharpe_white_noise_approx(long_span=21.0, sr_underlying=0.25),
+        atol=5e-3,
+    )

--- a/tests/test_sharpe_shared.py
+++ b/tests/test_sharpe_shared.py
@@ -3,10 +3,12 @@ guards for the shared Sharpe estimator: the formula identity, bit-parity with th
 expressions it replaced, and the cross-repo parity with the qis SharpeConvention
 proposal when a patched qis is installed (skips on released qis)
 """
+
 # packages
 import numpy as np
 import pandas as pd
 import pytest
+
 # project
 from trendfollowing.analytics.sharpe import compute_realized_sharpe
 
@@ -53,21 +55,37 @@ def test_regime_decomposition_parity_with_patched_qis():
         pytest.skip("installed qis predates the SharpeConvention proposal")
     gaussian_null = pytest.importorskip("papers.smart_diversification.replication.gaussian_null")
     import qis
+
     rng = np.random.RandomState(7)
     idx = pd.date_range('1990-12-31', periods=140, freq='QE')
-    bench = pd.Series(0.015 + 0.05 * rng.randn(140), index=idx).add(1.0).cumprod().rename('Balanced')
+    bench = (
+        pd.Series(0.015 + 0.05 * rng.randn(140), index=idx).add(1.0).cumprod().rename('Balanced')
+    )
     a1 = pd.Series(0.010 + 0.06 * rng.randn(140), index=idx).add(1.0).cumprod().rename('A1')
     prices = pd.concat([bench, a1], axis=1)
     sampled = prices.pct_change().dropna()
-    paper = gaussian_null.compute_regime_sharpe_decomposition(strategy_returns=sampled['A1'],
-                                                              benchmark_returns=sampled['Balanced'],
-                                                              periods_per_year=4.0, tail_prob=0.16)
+    paper = gaussian_null.compute_regime_sharpe_decomposition(
+        strategy_returns=sampled['A1'],
+        benchmark_returns=sampled['Balanced'],
+        periods_per_year=4.0,
+        tail_prob=0.16,
+    )
     perf_params = qis.PerfParams(freq='QE', sharpe_convention=config.SharpeConvention.ARITHMETIC)
-    table = qis.compute_bnb_regimes_pa_perf_table(prices=prices, benchmark='Balanced', freq='QE',
-                                                  q=np.array([0.0, 0.16, 0.84, 1.0]),
-                                                  perf_params=perf_params)
-    qis_row = table.loc['A1', [c for c in table.columns
-                               if 'Sharpe' in c and any(r in c for r in ('Bear', 'Normal', 'Bull'))]]
+    table = qis.compute_bnb_regimes_pa_perf_table(
+        prices=prices,
+        benchmark='Balanced',
+        freq='QE',
+        q=np.array([0.0, 0.16, 0.84, 1.0]),
+        perf_params=perf_params,
+    )
+    qis_row = table.loc[
+        'A1',
+        [
+            c
+            for c in table.columns
+            if 'Sharpe' in c and any(r in c for r in ('Bear', 'Normal', 'Bull'))
+        ],
+    ]
     diff = np.abs(np.array([paper['bear'], paper['normal'], paper['bull']]) - qis_row.to_numpy())
     assert diff.max() < 1e-14
 
@@ -87,9 +105,12 @@ def test_local_fallback_equals_standalone():
     # the local strict-inequality construction
     q_low, q_high = r_b.quantile(tail), r_b.quantile(1.0 - tail)
     sigma = r_a.std(ddof=1)
-    local = {'Bear-Sharpe': np.sqrt(4.0) * (r_b < q_low).mean() * r_a[r_b < q_low].mean() / sigma,
-             'Bull-Sharpe': np.sqrt(4.0) * (r_b > q_high).mean() * r_a[r_b > q_high].mean() / sigma}
-    standalone = rc.compute_regime_sharpe_decomposition(returns=r_a, benchmark_returns=r_b,
-                                                        af=4.0, q=np.array([0.0, tail, 1.0 - tail, 1.0]))
+    local = {
+        'Bear-Sharpe': np.sqrt(4.0) * (r_b < q_low).mean() * r_a[r_b < q_low].mean() / sigma,
+        'Bull-Sharpe': np.sqrt(4.0) * (r_b > q_high).mean() * r_a[r_b > q_high].mean() / sigma,
+    }
+    standalone = rc.compute_regime_sharpe_decomposition(
+        returns=r_a, benchmark_returns=r_b, af=4.0, q=np.array([0.0, tail, 1.0 - tail, 1.0])
+    )
     for key, value in local.items():
         assert abs(standalone[key] - value) < 1e-14

--- a/tests/test_smart_diversification.py
+++ b/tests/test_smart_diversification.py
@@ -1,19 +1,23 @@
-import pytest
-pytest.importorskip('papers.smart_diversification.replication.gaussian_null',
-                    reason='companion-paper folder not present in this checkout')
 """
-tests for the smart diversification analytics: kappa constants, null values, additivity, aggregation, frontier
+tests for the smart diversification analytics: kappa constants, null values,
+additivity, aggregation, and frontier
 """
 # packages
 import numpy as np
 import pandas as pd
+import pytest
+
 # project
-from papers.smart_diversification.replication.gaussian_null import (compute_kappa,
-                                                                           compute_null_regime_contributions,
-                                                                           compute_convexity_premium,
-                                                                           compute_regime_sharpe_decomposition,
-                                                                           compute_portfolio_bear_sharpe,
-                                                                           compute_blend_frontier)
+gaussian_null = pytest.importorskip(
+    'papers.smart_diversification.replication.gaussian_null',
+    reason='companion-paper folder not present in this checkout',
+)
+compute_kappa = gaussian_null.compute_kappa
+compute_null_regime_contributions = gaussian_null.compute_null_regime_contributions
+compute_convexity_premium = gaussian_null.compute_convexity_premium
+compute_regime_sharpe_decomposition = gaussian_null.compute_regime_sharpe_decomposition
+compute_portfolio_bear_sharpe = gaussian_null.compute_portfolio_bear_sharpe
+compute_blend_frontier = gaussian_null.compute_blend_frontier
 
 
 def test_kappa_constants():
@@ -49,19 +53,26 @@ def test_portfolio_aggregation_identity():
     rhos = np.array([1.0, 0.0])
     cps = np.array([0.0, 0.30])
     rho_assets = 0.0
-    cov = np.outer(weights * vols, weights * vols) * np.array([[1.0, rho_assets], [rho_assets, 1.0]])
+    cov = np.outer(weights * vols, weights * vols) * np.array(
+        [[1.0, rho_assets], [rho_assets, 1.0]]
+    )
     portfolio_vol = float(np.sqrt(cov.sum()))
-    bear_p = compute_portfolio_bear_sharpe(weights=weights, vols=vols, srs=srs, rhos=rhos, cps=cps,
-                                           portfolio_vol=portfolio_vol)
+    bear_p = compute_portfolio_bear_sharpe(
+        weights=weights, vols=vols, srs=srs, rhos=rhos, cps=cps, portfolio_vol=portfolio_vol
+    )
     # direct evaluation of the same identity
     kappa = compute_kappa()
     rw = weights * vols / portfolio_vol
-    direct = 0.16 * float(np.sum(rw * srs)) - kappa * float(np.sum(rw * rhos)) + float(np.sum(rw * cps))
+    direct = (
+        0.16 * float(np.sum(rw * srs)) - kappa * float(np.sum(rw * rhos)) + float(np.sum(rw * cps))
+    )
     assert np.isclose(bear_p, direct)
 
 
 def test_blend_frontier_endpoints_and_improvement():
-    frontier = compute_blend_frontier(sr_b=0.5, vol_b=0.10, sr_a=0.63, vol_a=0.15, rho=0.0, cp_a=0.30)
+    frontier = compute_blend_frontier(
+        sr_b=0.5, vol_b=0.10, sr_a=0.63, vol_a=0.15, rho=0.0, cp_a=0.30
+    )
     assert np.isclose(frontier['sharpe'].iloc[0], 0.5)
     assert np.isclose(frontier['sharpe'].iloc[-1], 0.63)
     assert np.isclose(frontier['sharpe'].max(), np.hypot(0.5, 0.63), atol=5e-3)
@@ -70,19 +81,25 @@ def test_blend_frontier_endpoints_and_improvement():
 
 
 def test_regime_states_frequencies():
-    import numpy as np, pandas as pd
+    import numpy as np
+    import pandas as pd
     from papers.smart_diversification.replication.regime_analysis import compute_regime_states
+
     rng = np.random.default_rng(3)
-    nav = pd.Series(100.0 * np.exp(np.cumsum(0.0002 + 0.01 * rng.standard_normal(6000))),
-                    index=pd.bdate_range('2000-01-03', periods=6000))
+    nav = pd.Series(
+        100.0 * np.exp(np.cumsum(0.0002 + 0.01 * rng.standard_normal(6000))),
+        index=pd.bdate_range('2000-01-03', periods=6000),
+    )
     states = compute_regime_states(benchmark_nav=nav, freq='QE')
     shares = states.value_counts(normalize=True)
     assert abs(shares['bear'] - 0.16) < 0.05 and abs(shares['bull'] - 0.16) < 0.05
 
 
 def test_block_bootstrap_cp_runs():
-    import numpy as np, pandas as pd
+    import numpy as np
+    import pandas as pd
     from papers.smart_diversification.replication.regime_analysis import block_bootstrap_cp
+
     rng = np.random.default_rng(5)
     r_b = pd.Series(rng.standard_normal(120))
     r_a = pd.Series(0.03 + 0.1 * r_b + rng.standard_normal(120))
@@ -91,23 +108,36 @@ def test_block_bootstrap_cp_runs():
 
 
 def test_realized_blend_frontier_endpoints():
-    import numpy as np, pandas as pd
-    from papers.smart_diversification.replication.regime_analysis import (compute_realized_blend_frontier,
-                                                                                 compute_regime_sharpe_decomposition,
-                                                                                 to_periodic_returns)
+    import numpy as np
+    import pandas as pd
+    from papers.smart_diversification.replication.regime_analysis import (
+        compute_realized_blend_frontier,
+        compute_regime_sharpe_decomposition,
+        to_periodic_returns,
+    )
+
     rng = np.random.default_rng(9)
     idx = pd.bdate_range('2000-01-03', periods=6000)
-    nav_b = pd.Series(100.0 * np.exp(np.cumsum(0.0002 + 0.01 * rng.standard_normal(6000))), index=idx)
-    nav_o = pd.Series(100.0 * np.exp(np.cumsum(0.0003 + 0.01 * rng.standard_normal(6000))), index=idx)
+    nav_b = pd.Series(
+        100.0 * np.exp(np.cumsum(0.0002 + 0.01 * rng.standard_normal(6000))), index=idx
+    )
+    nav_o = pd.Series(
+        100.0 * np.exp(np.cumsum(0.0003 + 0.01 * rng.standard_normal(6000))), index=idx
+    )
     frontier = compute_realized_blend_frontier(benchmark_nav=nav_b, overlay_nav=nav_o)
     joint = to_periodic_returns(pd.concat([nav_b, nav_o], axis=1))
-    d0 = compute_regime_sharpe_decomposition(strategy_returns=joint.iloc[:, 0], benchmark_returns=joint.iloc[:, 0])
+    d0 = compute_regime_sharpe_decomposition(
+        strategy_returns=joint.iloc[:, 0], benchmark_returns=joint.iloc[:, 0]
+    )
     assert abs(frontier['sharpe'].iloc[0] - d0['total']) < 1e-10
 
 
 def test_mc_null_values_of_appendix_rows():
     # the analytic nulls of the monthly and expanding rows: p*sr - kappa*rho
-    from papers.smart_diversification.replication.gaussian_null import compute_null_regime_contributions
+    from papers.smart_diversification.replication.gaussian_null import (
+        compute_null_regime_contributions,
+    )
+
     bear_m, _, _ = compute_null_regime_contributions(sr=0.5, rho=0.6, periods_per_year=12.0)
     assert np.isclose(bear_m, 0.16 * 0.5 - 0.8429 * 0.6, atol=1e-3)
     bear_q, _, _ = compute_null_regime_contributions(sr=0.5, rho=0.6, periods_per_year=4.0)
@@ -115,38 +145,65 @@ def test_mc_null_values_of_appendix_rows():
 
 
 def test_mc_expanding_scheme_is_unbiased():
-    from papers.smart_diversification.replication.mc_estimation_errors import simulate_estimation_errors
-    stats = simulate_estimation_errors(n_periods=106, sr=0.6, rho=0.0, scheme='expanding',
-                                       warmup=40, n_sims=400, n_corr_sims=400)
+    from papers.smart_diversification.replication.mc_estimation_errors import (
+        simulate_estimation_errors,
+    )
+
+    stats = simulate_estimation_errors(
+        n_periods=106, sr=0.6, rho=0.0, scheme='expanding', warmup=40, n_sims=400, n_corr_sims=400
+    )
     assert np.isclose(stats['null_bear_sharpe'], 0.096, atol=1e-3)
     # the mean estimate sits within two standard errors of the null on a small run
-    assert abs(stats['mean_bear_sharpe'] - stats['null_bear_sharpe']) < 2.0 * stats['se_bear_sharpe'] / np.sqrt(400) * 20
+    assert (
+        abs(stats['mean_bear_sharpe'] - stats['null_bear_sharpe'])
+        < 2.0 * stats['se_bear_sharpe'] / np.sqrt(400) * 20
+    )
 
 
 def test_returns_to_nav_with_base_round_trip():
     from papers.smart_diversification.replication.regime_analysis import returns_to_nav_with_base
-    r = pd.DataFrame({'x': [0.01, -0.02, 0.015]}, index=pd.date_range('2020-01-31', periods=3, freq='ME'))
+
+    r = pd.DataFrame(
+        {'x': [0.01, -0.02, 0.015]}, index=pd.date_range('2020-01-31', periods=3, freq='ME')
+    )
     navs = returns_to_nav_with_base(returns=r)
     back = navs.pct_change().dropna()
     assert len(back) == len(r) and np.allclose(back['x'].to_numpy(), r['x'].to_numpy())
 
 
 def test_anonymization_mapping_covers_the_sheet():
-    from papers.smart_diversification.replication.make_blind_package import build_anonymization_mapping
-    sheet = pd.DataFrame({'bear_sharpe': [0.4, 0.1, -0.3, -0.5, 0.6, 0.2],
-                          'group': ['CTA', 'CTA', 'LS', 'LS', 'LongVol', 'LongVol']},
-                         index=['a', 'b', 'c', 'd', 'e', 'f'])
+    from papers.smart_diversification.replication.make_blind_package import (
+        build_anonymization_mapping,
+    )
+
+    sheet = pd.DataFrame(
+        {
+            'bear_sharpe': [0.4, 0.1, -0.3, -0.5, 0.6, 0.2],
+            'group': ['CTA', 'CTA', 'LS', 'LS', 'LongVol', 'LongVol'],
+        },
+        index=['a', 'b', 'c', 'd', 'e', 'f'],
+    )
     mapping = build_anonymization_mapping(sheet=sheet)
-    assert mapping == {'a': 'CTA 1', 'b': 'CTA 2', 'c': 'LS 1', 'd': 'LS 2', 'e': 'QIS 1', 'f': 'QIS 2'}
+    assert mapping == {
+        'a': 'CTA 1',
+        'b': 'CTA 2',
+        'c': 'LS 1',
+        'd': 'LS 2',
+        'e': 'QIS 1',
+        'f': 'QIS 2',
+    }
 
 
 def test_shared_daily_annualisation_convention():
     # both papers annualise daily statistics with AF_DAILY = 260, not the qis-inferred 252
     import trendfollowing as tf
+
     assert tf.AF_DAILY == 260.0 and tf.PPY_QUARTERLY == 4.0 and tf.PPY_MONTHLY == 12.0
     rng = np.random.default_rng(11)
-    navs = pd.DataFrame({'x': 100.0 * np.exp(np.cumsum(0.01 * rng.standard_normal(500)))},
-                        index=pd.bdate_range('2020-01-02', periods=500))
+    navs = pd.DataFrame(
+        {'x': 100.0 * np.exp(np.cumsum(0.01 * rng.standard_normal(500)))},
+        index=pd.bdate_range('2020-01-02', periods=500),
+    )
     vol = tf.compute_daily_annualised_vol(navs=navs)
     manual = navs.pct_change().std() * np.sqrt(260.0)
     assert np.allclose(vol.to_numpy(), manual.to_numpy())

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -2,7 +2,6 @@
 tests for the packaged futures dataset: shapes, benchmarks, and metadata alignment
 """
 # packages
-import pandas as pd
 # project
 from trendfollowing.universe import load_data
 


### PR DESCRIPTION
## Summary
- prepare the approved non-breaking `trendfollowing` 1.1.0 adoption release
- synchronize project, citation, README, changelog, runtime, and documentation versions
- clear the declared Ruff E/F/W gate across package code, tests, and root examples, with narrow F401 exceptions only for intentional re-export modules
- fix the maintainer-only undefined `credit_df` entry and make screener output honor `TF_FIGURE_PATH`

## Verification
- `pytest tests/ -q`: 56 passed, 1 skipped
- `ruff check src/trendfollowing tests examples`: passed
- ARFIMA variance-scale verification: passed, published values unchanged
- EWMA variance verification: passed, published values unchanged
- Sphinx HTML and linkcheck with `-W --keep-going`: passed
- `python -m build` and `twine check dist/*`: passed
- wheel and sdist installed separately outside the checkout; quickstart, packaged `load_data()`, and `pip check` passed in both
- wheel SHA-256: `f5a2d9f6ab514f9c0771108c142c0b7586ec54557c4d865c1412a218b5176049`
- sdist SHA-256: `c33c7fe755b1b185698ab91fa4da7299f55afeead2f65c5f91449ae0adcc515e`

Publication remains gated on this PR's CI and merge. PyPI upload, tag creation, and GitHub Release creation will use the merged commit only.